### PR TITLE
Recalculate "Content-Length"-Header after widget injection

### DIFF
--- a/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
+++ b/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
@@ -105,6 +105,15 @@ public class HttpRequestMonitorFilterTest {
 	}
 
 	@Test
+	public void testWidgetInjectionAdjustsContentLengthHeader() throws IOException, ServletException {
+		final MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+		servletResponse.setContentLength(testHtml.length());
+		servletResponse.setCharacterEncoding("utf-8");
+		httpRequestMonitorFilter.doFilter(requestWithAccept("text/html"), servletResponse, writeInResponseWhenCallingDoFilter(testHtml));
+		assertEquals(5534, servletResponse.getContentLength());
+	}
+
+	@Test
 	public void testBinaryData() throws IOException, ServletException {
 		final MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 		httpRequestMonitorFilter.doFilter(requestWithAccept("text/html"), servletResponse,
@@ -160,7 +169,7 @@ public class HttpRequestMonitorFilterTest {
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				HttpServletResponse response = (HttpServletResponse) invocation.getArguments()[1];
-				if (Math.random() > 0.5) {
+				if (Math.random() > 0.5) { // TODO: non deterministic test behaviour
 					System.out.println("using writer");
 					response.getWriter().write(html);
 				} else {


### PR DESCRIPTION
~~Unfortunately i did not found a way to remove an existing header (except creating a~~

It would be possible to override the header methods in HttpServletResponseBufferWrapper to prevent Content-Length headers from being set. Unfortunately, i realized this right now while writing this pull request.

This pull request however determines the size of the content in the response charset and sets the content length header accordingly.
I would understand if you favor the removal of the content length header. If so, decline this pull request. I will then rewrite this probably on friday.