### PR TITLE
Add request monitor for Resteasy requests

### DIFF
--- a/cla/contributors/johnlcox.md
+++ b/cla/contributors/johnlcox.md
@@ -1,0 +1,27 @@
+2015-07-07
+
+I hereby agree to the terms of the Individual Contributors License
+Agreement, with MD5 checksum 3455f69ed223b9e5712f8bb3abf38190.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+John Leacox
+https://github.com/johnlcox
+
+
+
+2015-07-07
+
+I hereby agree to the terms of the Entity Contributors License
+Agreement, with MD5 checksum 3230b63601162567219de517a1be22b4.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+John Leacox, Cerner Corporation
+https://github.com/johnlcox

--- a/stagemonitor-web/build.gradle
+++ b/stagemonitor-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	provided 'javax.servlet:javax.servlet-api:3.0.1'
 	// optional
 	provided 'org.springframework:spring-webmvc:3.1.0.RELEASE'
+	provided 'org.jboss.resteasy:resteasy-jaxrs:3.0.10.Final'
 
 	testCompile 'org.springframework:spring-webmvc:4.1.0.RELEASE'
 	testCompile 'org.springframework:spring-test:4.1.0.RELEASE'

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
@@ -188,7 +188,7 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 			.defaultValue(null)
 			.configurationCategory(WEB_PLUGIN)
 			.build();
-	private ConfigurationOption<Boolean> onlyMvcOption = ConfigurationOption.booleanOption()
+	private ConfigurationOption<Boolean> monitorOnlySpringMvcOption = ConfigurationOption.booleanOption()
 			.key("stagemonitor.requestmonitor.spring.monitorOnlySpringMvcRequests")
 			.dynamic(true)
 			.label("Monitor only SpringMVC requests")
@@ -198,6 +198,17 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 					"Graphite will allocate.")
 			.defaultValue(false)
 			.configurationCategory("Spring MVC Plugin")
+			.build();
+	private ConfigurationOption<Boolean> monitorOnlyResteasyOption = ConfigurationOption.booleanOption()
+			.key("stagemonitor.requestmonitor.resteasy.monitorOnlyResteasyRequests")
+			.dynamic(true)
+			.label("Monitor only Resteasy reqeusts")
+			.description("Whether or not requests should be ignored, if they will not be handled by a Resteasy resource method.\n" +
+					"This is handy, if you are not interested in the performance of serving static files. " +
+					"Setting this to true can also significantly reduce the amount of files (and thus storing space) " +
+					"Graphite will allocate.")
+			.defaultValue(false)
+			.configurationCategory("Resteasy Plugin")
 			.build();
 
 	@Override
@@ -214,7 +225,13 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 		try {
 			Class.forName("org.springframework.web.servlet.HandlerMapping");
 		} catch (ClassNotFoundException e) {
-			configurationOptions.remove(onlyMvcOption);
+			configurationOptions.remove(monitorOnlySpringMvcOption);
+		}
+
+		try {
+			Class.forName("org.jboss.resteasy.core.ResourceMethodRegistry");
+		} catch (ClassNotFoundException e) {
+			configurationOptions.remove(monitorOnlyResteasyOption);
 		}
 
 		return configurationOptions;
@@ -293,7 +310,11 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 	}
 
 	public boolean isMonitorOnlySpringMvcRequests() {
-		return onlyMvcOption.getValue();
+		return monitorOnlySpringMvcOption.getValue();
+	}
+
+	public boolean isMonitorOnlyResteasyRequests() {
+		return monitorOnlyResteasyOption.getValue();
 	}
 
 	@Override

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/DefaultMonitoredHttpRequestFactory.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/DefaultMonitoredHttpRequestFactory.java
@@ -5,11 +5,13 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.stagemonitor.core.configuration.Configuration;
 import org.stagemonitor.web.monitor.filter.StatusExposingByteCountingServletResponse;
+import org.stagemonitor.web.monitor.resteasy.ResteasyMonitoredHttpRequest;
 import org.stagemonitor.web.monitor.spring.SpringMonitoredHttpRequest;
 
 public class DefaultMonitoredHttpRequestFactory implements MonitoredHttpRequestFactory {
 
 	private boolean springMvc;
+	private boolean resteasy;
 
 	public DefaultMonitoredHttpRequestFactory() {
 		try {
@@ -17,6 +19,13 @@ public class DefaultMonitoredHttpRequestFactory implements MonitoredHttpRequestF
 			springMvc = true;
 		} catch (ClassNotFoundException e) {
 			springMvc = false;
+		}
+
+		try {
+			Class.forName("org.jboss.resteasy.core.ResourceMethodRegistry");
+			resteasy = true;
+		} catch (ClassNotFoundException e) {
+			resteasy = false;
 		}
 	}
 
@@ -26,6 +35,8 @@ public class DefaultMonitoredHttpRequestFactory implements MonitoredHttpRequestF
 														   FilterChain filterChain, Configuration configuration) {
 		if (springMvc) {
 			return new SpringMonitoredHttpRequest(httpServletRequest, responseWrapper, filterChain, configuration);
+		} else if (resteasy) {
+			return new ResteasyMonitoredHttpRequest(httpServletRequest, responseWrapper, filterChain, configuration);
 		}
 		return new MonitoredHttpRequest(httpServletRequest, responseWrapper, filterChain, configuration);
 	}

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyMonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyMonitoredHttpRequest.java
@@ -58,7 +58,7 @@ public class ResteasyMonitoredHttpRequest extends MonitoredHttpRequest {
 			name = getRequestNameFromInvoker(invoker, requestMonitorPlugin.getBusinessTransactionNamingStrategy());
 
 			if (!name.isEmpty()) {
-			  return name;
+				return name;
 			}
 
 			if (!webPlugin.isMonitorOnlyResteasyRequests()) {

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyMonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyMonitoredHttpRequest.java
@@ -1,0 +1,211 @@
+package org.stagemonitor.web.monitor.resteasy;
+
+import org.jboss.resteasy.core.ResourceInvoker;
+import org.jboss.resteasy.core.ResourceMethodInvoker;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.plugins.server.servlet.ServletUtil;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.Registry;
+import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.stagemonitor.core.configuration.Configuration;
+import org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy;
+import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
+import org.stagemonitor.web.monitor.MonitoredHttpRequest;
+import org.stagemonitor.web.monitor.filter.StatusExposingByteCountingServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Enumeration;
+
+/**
+ * A {@link MonitoredHttpRequest} for Resteasy requests.
+ *
+ * <p>This class will use the Resteasy jax-rs resource class and method for naming the request.
+ */
+public class ResteasyMonitoredHttpRequest extends MonitoredHttpRequest {
+	private static String servletMappingPrefix;
+
+	private final RequestMonitorPlugin requestMonitorPlugin;
+
+	public ResteasyMonitoredHttpRequest(
+			HttpServletRequest httpServletRequest,
+			StatusExposingByteCountingServletResponse statusExposingResponse,
+			FilterChain filterChain, Configuration configuration) {
+		super(httpServletRequest, statusExposingResponse, filterChain, configuration);
+		requestMonitorPlugin = configuration.getConfig(RequestMonitorPlugin.class);
+	}
+
+	@Override
+	public String getRequestName() {
+		ServletContext servletContext = httpServletRequest.getServletContext();
+		String servletMappingPrefix = getServletMappingPrefix(servletContext);
+		Registry registry = (Registry) servletContext.getAttribute(Registry.class.getName());
+
+		String name = "";
+		if (registry == null) {
+			name = super.getRequestName();
+		} else {
+			HttpRequest request = new RegistryLookupHttpRequest(httpServletRequest, servletMappingPrefix);
+			ResourceInvoker invoker = registry.getResourceInvoker(request);
+			name = getRequestNameFromInvoker(invoker, requestMonitorPlugin.getBusinessTransactionNamingStrategy());
+
+			if (!name.isEmpty()) {
+			  return name;
+			}
+
+			if (!webPlugin.isMonitorOnlyResteasyRequests()) {
+				name = super.getRequestName();
+			}
+		}
+
+		return name;
+	}
+
+	private String getServletMappingPrefix(ServletContext servletContext) {
+		if (servletMappingPrefix != null) {
+			return servletMappingPrefix;
+		}
+
+		servletMappingPrefix = servletContext
+				.getInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX);
+		if (servletMappingPrefix == null) {
+			servletMappingPrefix = "";
+		}
+		servletMappingPrefix = servletMappingPrefix.trim();
+
+		return servletMappingPrefix;
+	}
+
+	/**
+	 * Gets the Resteasy request name using the given {@link ResourceInvoker} to lookup the Resteasy resource class and
+	 * method.
+	 *
+	 * <p>The naming strategy can be specified by the {@code businessTransactionNamingStrategy} parameter. Acceptable
+	 * values can be found in {@link BusinessTransactionNamingStrategy}.
+	 */
+	static String getRequestNameFromInvoker(ResourceInvoker invoker, BusinessTransactionNamingStrategy businessTransactionNamingStrategy) {
+		if (invoker != null && invoker instanceof ResourceMethodInvoker) {
+			Method resourceMethod = invoker.getMethod();
+			return businessTransactionNamingStrategy.getBusinessTransationName(
+					resourceMethod.getDeclaringClass().getSimpleName(), resourceMethod.getName());
+		}
+		return "";
+	}
+
+	/**
+	 * A Resteasy {@link HttpRequest} implementation for wrapping an {@link HttpServletRequest} instance for resource
+	 * class lookups using {@link Registry}.
+	 */
+	private static class RegistryLookupHttpRequest implements HttpRequest {
+		private final HttpServletRequest httpServletRequest;
+		private final ResteasyUriInfo uri;
+		private final ResteasyHttpHeaders headers;
+
+		RegistryLookupHttpRequest(HttpServletRequest httpServletRequest, String servletMappingPrefix) {
+			this.httpServletRequest = httpServletRequest;
+			this.uri = ServletUtil.extractUriInfo(httpServletRequest, servletMappingPrefix);
+			this.headers = ServletUtil.extractHttpHeaders(httpServletRequest);
+		}
+
+		@Override
+		public HttpHeaders getHttpHeaders() {
+			return headers;
+		}
+
+		@Override
+		public MultivaluedMap<String, String> getMutableHeaders() {
+			return null;
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return null;
+		}
+
+		@Override
+		public void setInputStream(InputStream stream) {
+
+		}
+
+		@Override
+		public ResteasyUriInfo getUri() {
+			return uri;
+		}
+
+		@Override
+		public String getHttpMethod() {
+			return httpServletRequest.getMethod();
+		}
+
+		@Override
+		public void setHttpMethod(String method) {
+
+		}
+
+		@Override
+		public void setRequestUri(URI requestUri) throws IllegalStateException {
+
+		}
+
+		@Override
+		public void setRequestUri(URI baseUri, URI requestUri) throws IllegalStateException {
+
+		}
+
+		@Override
+		public MultivaluedMap<String, String> getFormParameters() {
+			return null;
+		}
+
+		@Override
+		public MultivaluedMap<String, String> getDecodedFormParameters() {
+			return null;
+		}
+
+		@Override
+		public Object getAttribute(String attribute) {
+			return httpServletRequest.getAttribute(attribute);
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+		}
+
+		@Override
+		public void removeAttribute(String name) {
+		}
+
+		@Override
+		public Enumeration<String> getAttributeNames() {
+			return httpServletRequest.getAttributeNames();
+		}
+
+		@Override
+		public ResteasyAsynchronousContext getAsyncContext() {
+			return null;
+		}
+
+		@Override
+		public boolean isInitial() {
+			return true;
+		}
+
+		@Override
+		public void forward(String path) {
+
+		}
+
+		@Override
+		public boolean wasForwarded() {
+			return false;
+		}
+	}
+}

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyRequestNameDeterminerInstrumenter.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/resteasy/ResteasyRequestNameDeterminerInstrumenter.java
@@ -1,0 +1,56 @@
+package org.stagemonitor.web.monitor.resteasy;
+
+import javassist.CtClass;
+import org.jboss.resteasy.core.ResourceInvoker;
+import org.stagemonitor.core.Stagemonitor;
+import org.stagemonitor.core.instrument.StagemonitorJavassistInstrumenter;
+import org.stagemonitor.requestmonitor.RequestMonitor;
+import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
+import org.stagemonitor.web.WebPlugin;
+
+/**
+ * A {@link StagemonitorJavassistInstrumenter} implementation for naming Resteasy requests.
+ */
+public class ResteasyRequestNameDeterminerInstrumenter extends StagemonitorJavassistInstrumenter {
+	private static WebPlugin webPlugin = Stagemonitor.getConfiguration(WebPlugin.class);
+	private static RequestMonitorPlugin requestMonitorPlugin = Stagemonitor.getConfiguration(RequestMonitorPlugin.class);
+
+	@Override
+	public boolean isIncluded(String className) {
+		return className.equals("org/jboss/resteasy/core/ResourceMethodRegistry");
+	}
+
+	@Override
+	public void transformClass(CtClass ctClass, ClassLoader loader) throws Exception {
+		ctClass.getDeclaredMethod("getResourceInvoker")
+				.insertAfter(
+						"com.cerner.beadledom.stagemonitor.request.ResteasyRequestNameDeterminerInstrumenter"
+								+ "setRequestNameByInvoker($_);");
+	}
+
+	/**
+	 * Set the request name by looking up the Resteasy resource and method using the provided {@link ResourceInvoker}.
+	 */
+	public static void setRequestNameByInvoker(ResourceInvoker invoker) {
+		if (RequestMonitor.getRequest() != null) {
+			String requestName = "";
+			if (invoker != null) {
+				requestName = ResteasyMonitoredHttpRequest.getRequestNameFromInvoker(invoker,
+						requestMonitorPlugin.getBusinessTransactionNamingStrategy());
+			}
+			// requests with empty names don't get monitored
+			// requestNames with non null values don't get overwritten and avoid GetNameCallback#getName to be called
+			if (!requestName.isEmpty() || webPlugin.isMonitorOnlyResteasyRequests()) {
+				RequestMonitor.getRequest().setName(requestName);
+			}
+		}
+	}
+
+	static void setWebPlugin(WebPlugin webPlugin) {
+		ResteasyRequestNameDeterminerInstrumenter.webPlugin = webPlugin;
+	}
+
+	static void setRequestMonitorPlugin(RequestMonitorPlugin requestMonitorPlugin) {
+		ResteasyRequestNameDeterminerInstrumenter.requestMonitorPlugin = requestMonitorPlugin;
+	}
+}

--- a/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/resteasy/ResteasyRequestMonitorTest.java
+++ b/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/resteasy/ResteasyRequestMonitorTest.java
@@ -1,0 +1,248 @@
+package org.stagemonitor.web.monitor.resteasy;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.stagemonitor.core.util.GraphiteSanitizer.sanitizeGraphiteMetricSegment;
+import static org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy.METHOD_NAME_SPLIT_CAMEL_CASE;
+import static org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy.CLASS_NAME_HASH_METHOD_NAME;
+import static org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy.CLASS_NAME_DOT_METHOD_NAME;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import org.jboss.resteasy.core.ResourceInvoker;
+import org.jboss.resteasy.core.ResourceMethodInvoker;
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.Registry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.stagemonitor.core.CorePlugin;
+import org.stagemonitor.core.configuration.Configuration;
+import org.stagemonitor.requestmonitor.RequestMonitor;
+import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
+import org.stagemonitor.web.WebPlugin;
+import org.stagemonitor.web.monitor.HttpRequestTrace;
+import org.stagemonitor.web.monitor.filter.StatusExposingByteCountingServletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+@RunWith(value = Parameterized.class)
+public class ResteasyRequestMonitorTest {
+    private MockHttpServletRequest resteasyServletRequest = new MockHttpServletRequest("GET", "/test/requestName");
+    private MockHttpServletRequest nonResteasyServletRequest = new MockHttpServletRequest("GET", "/META-INF/resources/stagemonitor/static/jquery.js");
+    private MockHttpRequest resteasyRequest;
+    private Configuration configuration = mock(Configuration.class);
+    private RequestMonitorPlugin requestMonitorPlugin = mock(RequestMonitorPlugin.class);
+    private WebPlugin webPlugin = mock(WebPlugin.class);
+    private CorePlugin corePlugin = mock(CorePlugin.class);
+    private RequestMonitor requestMonitor;
+    private MetricRegistry registry = new MetricRegistry();
+    private final boolean useNameDeterminerAspect;
+    private Registry getRequestNameRegistry;
+
+    public ResteasyRequestMonitorTest(boolean useNameDeterminerAspect) {
+        this.useNameDeterminerAspect = useNameDeterminerAspect;
+    }
+
+    // the purpose of this class is to obtain a instance to a Method,
+    // because Method objects can't be mocked as they are final
+    private static class TestResource { public void testGetRequestName() {} }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] { { true }, { false } };
+        return Arrays.asList(data);
+    }
+
+    @Before
+    public void before() throws Exception {
+        resteasyRequest = MockHttpRequest.create(resteasyServletRequest.getMethod(), resteasyServletRequest.getRequestURI());
+        getRequestNameRegistry = createRegistry(resteasyRequest, TestResource.class.getMethod("testGetRequestName"));
+        resteasyServletRequest.getServletContext().setAttribute(Registry.class.getName(), getRequestNameRegistry);
+        nonResteasyServletRequest.getServletContext().setAttribute(Registry.class.getName(), getRequestNameRegistry);
+        registry.removeMatching(new MetricFilter() {
+            @Override
+            public boolean matches(String name, Metric metric) {
+                return true;
+            }
+        });
+        when(configuration.getConfig(RequestMonitorPlugin.class)).thenReturn(requestMonitorPlugin);
+        when(configuration.getConfig(WebPlugin.class)).thenReturn(webPlugin);
+        when(configuration.getConfig(CorePlugin.class)).thenReturn(corePlugin);
+        when(corePlugin.isStagemonitorActive()).thenReturn(true);
+        when(requestMonitorPlugin.isCollectRequestStats()).thenReturn(true);
+        when(requestMonitorPlugin.getBusinessTransactionNamingStrategy()).thenReturn(METHOD_NAME_SPLIT_CAMEL_CASE);
+        when(webPlugin.getGroupUrls()).thenReturn(Collections.singletonMap(Pattern.compile("(.*).js$"), "*.js"));
+        requestMonitor = new RequestMonitor(corePlugin, registry, requestMonitorPlugin);
+        ResteasyRequestNameDeterminerInstrumenter.setWebPlugin(webPlugin);
+        ResteasyRequestNameDeterminerInstrumenter.setRequestMonitorPlugin(requestMonitorPlugin);
+    }
+
+    private Registry createRegistry(final MockHttpRequest request, Method requestMappingMethod) {
+        ResourceInvoker invoker = mock(ResourceMethodInvoker.class);
+        when(invoker.getMethod()).thenReturn(requestMappingMethod);
+
+        ArgumentMatcher<HttpRequest> httpRequestMatcher = new ArgumentMatcher<HttpRequest>() {
+            @Override
+            public boolean matches(Object argument) {
+                if (argument == null) {
+                    return false;
+                }
+
+                if (!HttpRequest.class.isAssignableFrom(argument.getClass())) {
+                    return false;
+                }
+
+                HttpRequest other = (HttpRequest) argument;
+                return request.getUri().getPath().equals(other.getUri().getPath())
+                        && request.getHttpMethod().equals(other.getHttpMethod());
+            }
+        };
+
+        Registry registry = mock(Registry.class);
+        when(registry.getResourceInvoker(argThat(httpRequestMatcher))).thenReturn(invoker);
+        return registry;
+    }
+
+    @Test
+    public void testRequestMonitorResteasyRequest() throws Exception {
+        System.out.println("useNameDeterminerAspect="+useNameDeterminerAspect);
+        when(webPlugin.isMonitorOnlyResteasyRequests()).thenReturn(false);
+
+        ResteasyMonitoredHttpRequest monitoredRequest = createResteasyMonitoredHttpRequest(resteasyServletRequest);
+        registerAspect(monitoredRequest, getRequestNameRegistry.getResourceInvoker(resteasyRequest));
+        final RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation = requestMonitor.monitor(monitoredRequest);
+
+        assertEquals(1, requestInformation.getRequestTimer().getCount());
+        assertEquals("Test-Get-Request-Name", requestInformation.getTimerName());
+        assertEquals("Test Get Request Name", requestInformation.getRequestTrace().getName());
+        assertEquals("/test/requestName", requestInformation.getRequestTrace().getUrl());
+        assertEquals(Integer.valueOf(200), requestInformation.getRequestTrace().getStatusCode());
+        assertEquals("GET", requestInformation.getRequestTrace().getMethod());
+        Assert.assertNull(requestInformation.getExecutionResult());
+        assertNotNull(registry.getTimers().get(name("request", "Test-Get-Request-Name", "server", "time", "total")));
+        verify(monitoredRequest, times(1)).onPostExecute(anyRequestInformation());
+        verify(monitoredRequest, times(useNameDeterminerAspect ? 0 : 1)).getRequestName();
+    }
+
+    @Test
+    public void testRequestMonitorResteasyRequestWithClassHashMethodNaming() throws Exception {
+        System.out.println("useNameDeterminerAspect="+useNameDeterminerAspect);
+        when(webPlugin.isMonitorOnlyResteasyRequests()).thenReturn(false);
+        when(requestMonitorPlugin.getBusinessTransactionNamingStrategy()).thenReturn(CLASS_NAME_HASH_METHOD_NAME);
+
+        ResteasyMonitoredHttpRequest monitoredRequest = createResteasyMonitoredHttpRequest(resteasyServletRequest);
+        registerAspect(monitoredRequest, getRequestNameRegistry.getResourceInvoker(resteasyRequest));
+        final RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation = requestMonitor.monitor(monitoredRequest);
+
+        assertEquals(1, requestInformation.getRequestTimer().getCount());
+        assertEquals("TestResource#testGetRequestName", requestInformation.getTimerName());
+        assertEquals("TestResource#testGetRequestName", requestInformation.getRequestTrace().getName());
+        assertEquals("/test/requestName", requestInformation.getRequestTrace().getUrl());
+        assertEquals(Integer.valueOf(200), requestInformation.getRequestTrace().getStatusCode());
+        assertEquals("GET", requestInformation.getRequestTrace().getMethod());
+        Assert.assertNull(requestInformation.getExecutionResult());
+        assertNotNull(registry.getTimers().get(name("request", "TestResource#testGetRequestName", "server", "time", "total")));
+        verify(monitoredRequest, times(1)).onPostExecute(anyRequestInformation());
+        verify(monitoredRequest, times(useNameDeterminerAspect ? 0 : 1)).getRequestName();
+    }
+
+    @Test
+    public void testRequestMonitorResteasyRequestWithClassDotMethodNaming() throws Exception {
+        System.out.println("useNameDeterminerAspect="+useNameDeterminerAspect);
+        when(webPlugin.isMonitorOnlyResteasyRequests()).thenReturn(false);
+        when(requestMonitorPlugin.getBusinessTransactionNamingStrategy()).thenReturn(CLASS_NAME_DOT_METHOD_NAME);
+
+        ResteasyMonitoredHttpRequest monitoredRequest = createResteasyMonitoredHttpRequest(resteasyServletRequest);
+        registerAspect(monitoredRequest, getRequestNameRegistry.getResourceInvoker(resteasyRequest));
+        final RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation = requestMonitor.monitor(monitoredRequest);
+
+        assertEquals(1, requestInformation.getRequestTimer().getCount());
+        // Timer names repalces '.' with ':' for graphite
+        assertEquals("TestResource:testGetRequestName", requestInformation.getTimerName());
+        assertEquals("TestResource.testGetRequestName", requestInformation.getRequestTrace().getName());
+        assertEquals("/test/requestName", requestInformation.getRequestTrace().getUrl());
+        assertEquals(Integer.valueOf(200), requestInformation.getRequestTrace().getStatusCode());
+        assertEquals("GET", requestInformation.getRequestTrace().getMethod());
+        Assert.assertNull(requestInformation.getExecutionResult());
+        assertNotNull(registry.getTimers().get(name("request", "TestResource:testGetRequestName", "server", "time", "total")));
+        verify(monitoredRequest, times(1)).onPostExecute(anyRequestInformation());
+        verify(monitoredRequest, times(useNameDeterminerAspect ? 0 : 1)).getRequestName();
+    }
+
+    @Test
+    public void testRequestMonitorNonResteasyRequestDoMonitor() throws Exception {
+        when(webPlugin.isMonitorOnlyResteasyRequests()).thenReturn(false);
+
+        ResteasyMonitoredHttpRequest monitoredRequest = createResteasyMonitoredHttpRequest(nonResteasyServletRequest);
+        registerAspect(monitoredRequest, getRequestNameRegistry.getResourceInvoker(resteasyRequest));
+        registerAspect(monitoredRequest, null);
+        RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation = requestMonitor.monitor(monitoredRequest);
+
+        assertEquals(1, requestInformation.getRequestTimer().getCount());
+        assertEquals("GET-*:js", requestInformation.getTimerName());
+        assertEquals("GET *.js", requestInformation.getRequestTrace().getName());
+        assertNotNull(registry.getTimers().get(name("request", "GET-*:js", "server", "time", "total")));
+        verify(monitoredRequest, times(1)).onPostExecute(anyRequestInformation());
+        verify(monitoredRequest, times(1)).getRequestName();
+    }
+
+    @Test
+    public void testRequestMonitorNonResteasyRequestDontMonitor() throws Exception {
+        when(webPlugin.isMonitorOnlyResteasyRequests()).thenReturn(true);
+
+        ResteasyMonitoredHttpRequest monitoredRequest = createResteasyMonitoredHttpRequest(nonResteasyServletRequest);
+        registerAspect(monitoredRequest, getRequestNameRegistry.getResourceInvoker(resteasyRequest));
+        registerAspect(monitoredRequest, null);
+        RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation = requestMonitor.monitor(monitoredRequest);
+
+        assertEquals("", requestInformation.getRequestTrace().getName());
+        assertNull(registry.getTimers().get(name("request", sanitizeGraphiteMetricSegment("GET *.js"), "server", "time", "total")));
+        verify(monitoredRequest, never()).onPostExecute(anyRequestInformation());
+        verify(monitoredRequest, times(useNameDeterminerAspect ? 0 : 1)).getRequestName();
+    }
+
+    private void registerAspect(ResteasyMonitoredHttpRequest monitoredRequest, final ResourceInvoker invoker) throws Exception {
+        if (useNameDeterminerAspect) {
+            when(monitoredRequest.execute()).thenAnswer(new Answer<Object>() {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable {
+                    ResteasyRequestNameDeterminerInstrumenter.setRequestNameByInvoker(invoker);
+                    return null;
+                }
+            });
+        }
+    }
+
+    private RequestMonitor.RequestInformation<HttpRequestTrace> anyRequestInformation() {
+        return any();
+    }
+
+    private ResteasyMonitoredHttpRequest createResteasyMonitoredHttpRequest(HttpServletRequest request) throws IOException {
+        final StatusExposingByteCountingServletResponse response = new StatusExposingByteCountingServletResponse(new MockHttpServletResponse());
+        return Mockito.spy(new ResteasyMonitoredHttpRequest(request, response, new MockFilterChain(), configuration));
+    }
+}


### PR DESCRIPTION
Adds support for monitoring Resteasy requests by looking up the jax-rs resource and class to use in determining the request name. This is the implementation for #80.