### PR TITLE
Fix non thread safe list

### DIFF
--- a/stagemonitor-jdbc/src/main/java/org/stagemonitor/jdbc/p6spy/P6SpyMultiLogger.java
+++ b/stagemonitor-jdbc/src/main/java/org/stagemonitor/jdbc/p6spy/P6SpyMultiLogger.java
@@ -3,12 +3,12 @@ package org.stagemonitor.jdbc.p6spy;
 import com.p6spy.engine.logging.Category;
 import com.p6spy.engine.spy.appender.P6Logger;
 
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class P6SpyMultiLogger implements P6Logger {
 
-	private static List<P6Logger> loggers = new LinkedList<P6Logger>();
+	private static List<P6Logger> loggers = new CopyOnWriteArrayList<P6Logger>();
 
 	public static void addLogger(P6Logger logger) {
 		if (logger != null) {


### PR DESCRIPTION
If seen this in our CI:

```
[INFO] STDOUT: Caused by: java.lang.NullPointerException
at java.util.LinkedList$ListItr.next(LinkedList.java:893)
~[?:1.8.0_60]
at org.stagemonitor.jdbc.p6spy.P6SpyMultiLogger.isCategoryEnabled(P6SpyMultiLogger.java:45)
~[stagemonitor-jdbc-0.18.0.jar!/:0.18.0]
at com.p6spy.engine.common.P6LogQuery.isCategoryOk(P6LogQuery.java:169)
~[p6spy-2.1.4.jar!/:?]
at com.p6spy.engine.common.P6LogQuery.logElapsed(P6LogQuery.java:209)
~[p6spy-2.1.4.jar!/:?]
at com.p6spy.engine.common.P6LogQuery.logElapsed(P6LogQuery.java:203)
~[p6spy-2.1.4.jar!/:?]
at com.p6spy.engine.logging.P6LogStatementExecuteDelegate.invoke(P6LogStatementExecuteDelegate.java:51) ~[p6spy-2.1.4.jar!/:?]
```

Linked Lists and their iterators are not thread safe, so as we have a shared
static instance here I guess that needs to be somewhat safer.