### PR TITLE
Fixed an issue where the request trace servlet cleanup thread would o…

### DIFF
--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/widget/RequestTraceServlet.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/widget/RequestTraceServlet.java
@@ -65,7 +65,8 @@ public class RequestTraceServlet extends HttpServlet implements RequestTraceRepo
 		this.requestTimeout = requestTimeout;
 		this.configuration = configuration;
 		this.webPlugin = configuration.getConfig(WebPlugin.class);
-		oldRequestTracesRemoverPool.schedule(new OldRequestTraceRemover(), MAX_REQUEST_TRACE_BUFFERING_TIME, TimeUnit.MILLISECONDS);
+		oldRequestTracesRemoverPool.scheduleAtFixedRate(new OldRequestTraceRemover(), 
+				MAX_REQUEST_TRACE_BUFFERING_TIME, MAX_REQUEST_TRACE_BUFFERING_TIME, TimeUnit.MILLISECONDS);
 	}
 
 	@Override


### PR DESCRIPTION
…nly run once instead of every 60 seconds to cleanup traces that are never picked up by the client.