### PR TITLE
Fix thread safety of RequestMonitor

### DIFF
--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -49,9 +49,9 @@ public class RequestMonitor {
 		add(new ElasticsearchRequestTraceReporter());
 	}};
 
-	private final List<Runnable> onBeforeRequestCallbacks = new LinkedList<Runnable>();
+	private final List<Runnable> onBeforeRequestCallbacks = new CopyOnWriteArrayList<Runnable>();
 
-	private final List<Runnable> onAfterRequestCallbacks = new LinkedList<Runnable>();
+	private final List<Runnable> onAfterRequestCallbacks = new CopyOnWriteArrayList<Runnable>();
 
 	private ExecutorService asyncRequestTraceReporterPool;
 


### PR DESCRIPTION
When using the agent, onBeforeRequestCallbacks will be initialized from the
RequestMonitor startup thread. The callbacks will be executed by the actual
request thread. As there are no synchronization guarantees with the linked
lists this can lead to exceptions while iterating:

java.lang.NullPointerException
at java.util.LinkedList$ListItr.next(LinkedList.java:893) ~[?:1.8.0_60]
at org.stagemonitor.requestmonitor.RequestMonitor.beforeExecution(RequestMonitor.java:219)
at org.stagemonitor.requestmonitor.RequestMonitor.monitorStart(RequestMonitor.java:115)
at org.stagemonitor.requestmonitor.RequestMonitor.monitor(RequestMonitor.java:162)
at org.stagemonitor.web.monitor.filter.HttpRequestMonitorFilter.monitorRequest(HttpRequestMonitorFilter.java:169)
at org.stagemonitor.web.monitor.filter.HttpRequestMonitorFilter.doMonitor(HttpRequestMonitorFilter.java:125)
at org.stagemonitor.web.monitor.filter.HttpRequestMonitorFilter.doFilterInternal(HttpRequestMonitorFilter.java:103)
at org.stagemonitor.web.monitor.filter.AbstractExclusionFilter.doFilter(AbstractExclusionFilter.java:75)