### PR TITLE
Add an additional filter that runs after other filters to populate us…

### DIFF
--- a/cla/contributors/ryanrupp.md
+++ b/cla/contributors/ryanrupp.md
@@ -1,0 +1,27 @@
+2015-11-11
+
+I hereby agree to the terms of the Entity Contributors License
+Agreement, with MD5 checksum 3230b63601162567219de517a1be22b4.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+Ryan Rupp, MacGregor Partners
+https://github.com/ryanrupp
+
+---
+
+2015-11-11
+
+I hereby agree to the terms of the Individual Contributors License
+Agreement, with MD5 checksum 3455f69ed223b9e5712f8bb3abf38190.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+Ryan Rupp
+https://github.com/ryanrupp

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
@@ -40,6 +40,7 @@ import org.stagemonitor.web.metrics.StagemonitorMetricsServlet;
 import org.stagemonitor.web.monitor.MonitoredHttpRequest;
 import org.stagemonitor.web.monitor.filter.HttpRequestMonitorFilter;
 import org.stagemonitor.web.monitor.filter.StagemonitorSecurityFilter;
+import org.stagemonitor.web.monitor.filter.UserNameFilter;
 import org.stagemonitor.web.monitor.rum.RumServlet;
 import org.stagemonitor.web.monitor.servlet.FileServlet;
 import org.stagemonitor.web.monitor.spring.SpringMonitoredHttpRequest;
@@ -359,6 +360,11 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 		final FilterRegistration.Dynamic monitorFilter = ctx.addFilter(HttpRequestMonitorFilter.class.getSimpleName(), new HttpRequestMonitorFilter());
 		monitorFilter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD), false, "/*");
 		monitorFilter.setAsyncSupported(true);
+		
+		final FilterRegistration.Dynamic userFilter = ctx.addFilter(UserNameFilter.class.getSimpleName(), new UserNameFilter());
+		// Have this filter run last because user information may be populated by other filters e.g. Spring Security
+		userFilter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD), true, "/*");
+		userFilter.setAsyncSupported(true);
 
 
 		ctx.addListener(MDCListener.class);

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/UserNameFilter.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/UserNameFilter.java
@@ -1,0 +1,48 @@
+package org.stagemonitor.web.monitor.filter;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.stagemonitor.core.Stagemonitor;
+import org.stagemonitor.core.configuration.Configuration;
+import org.stagemonitor.requestmonitor.RequestMonitor;
+import org.stagemonitor.requestmonitor.RequestTrace;
+import org.stagemonitor.web.WebPlugin;
+
+/**
+ * Populates user name on the request trace. Dedicated to its own filter
+ * so it can be configured to run as the last filter in the filter chain
+ * as this information may not be available until that point.
+ *
+ */
+public class UserNameFilter extends AbstractExclusionFilter {
+	
+	public UserNameFilter() {
+		this(Stagemonitor.getConfiguration());
+	}
+
+	public UserNameFilter(Configuration configuration) {
+		super(configuration.getConfig(WebPlugin.class).getExcludedRequestPaths());
+	}
+
+	@Override
+	public void doFilterInternal(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
+			FilterChain filterChain) throws IOException, ServletException {
+		RequestTrace requestTrace = RequestMonitor.getRequest();
+		if (requestTrace != null && requestTrace.getUsername() == null) {
+			requestTrace.setUsername(getUserName(servletRequest));
+		}
+		
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+	
+	private static String getUserName(HttpServletRequest servletRequest) {
+		Principal userPrincipal = servletRequest.getUserPrincipal();
+		return userPrincipal != null ? userPrincipal.getName() : null;
+	}
+}


### PR DESCRIPTION
…er information as this information may not actually be available until after the other filters have run e.g. Spring Security which wraps the HttpServletRequest object in its filters populating the User Principal information.