### PR TITLE
Changed how exceptions on requests are found by allowing a list of at…

### DIFF
--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/WebPlugin.java
@@ -214,6 +214,22 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 			.defaultValue(false)
 			.configurationCategory("Resteasy Plugin")
 			.build();
+	private ConfigurationOption<Collection<String>> requestExceptionAttributes = ConfigurationOption.stringsOption()
+			.key("stagemonitor.requestmonitor.requestExceptionAttributes")
+			.dynamic(true)
+			.label("Request Exception Attributes")
+			.description("Defines the list of attribute names to check on the HttpServletRequest when searching for an exception. \n\n" +
+			             "Stagemonitor searches this list in order to see if any of these attributes are set on the request with " +
+					     "an Exception object and then records that information on the request trace. If your web framework " +
+			             "sets a different attribute outside of the defaults, you can add that attribute to this list to properly " +
+					     "record the exception on the trace.")
+			.defaultValue(new LinkedHashSet<String>() {{
+				add("javax.servlet.error.exception");
+				add("exception");
+				add("org.springframework.web.servlet.DispatcherServlet.EXCEPTION");
+			}})
+			.configurationCategory(WEB_PLUGIN)
+			.build();
 
 	@Override
 	public void initializePlugin(Metric2Registry registry, Configuration config) {
@@ -330,6 +346,10 @@ public class WebPlugin extends StagemonitorPlugin implements ServletContainerIni
 
 	public boolean isMonitorOnlyResteasyRequests() {
 		return monitorOnlyResteasyOption.getValue();
+	}
+	
+	public Collection<String> getRequestExceptionAttributes() {
+		return requestExceptionAttributes.getValue();
 	}
 
 	@Override

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
@@ -195,10 +195,16 @@ public class MonitoredHttpRequest implements MonitoredRequest<HttpRequestTrace> 
 			request.setError(true);
 		}
 
-		Object exception = httpServletRequest.getAttribute("exception");
-		if (exception != null && exception instanceof Exception) {
-			request.setException((Exception) exception);
+		// Search the configured exception attributes that may have been set
+		// by the servlet container/framework. Use the first exception found (if any)
+		for (String requestExceptionAttribute : webPlugin.getRequestExceptionAttributes()) {
+			Object exception = httpServletRequest.getAttribute(requestExceptionAttribute);
+			if (exception != null && exception instanceof Exception) {
+				request.setException((Exception) exception);
+				break;
+			}
 		}
+		
 		request.setBytesWritten(responseWrapper.getContentLength());
 
 		// get the parameters after the execution and not on creation, because that could lead to wrong decoded


### PR DESCRIPTION
…tributes to be defined that are inspected on the HttpServletRequest when the request completes. This is so that exceptions can properly get captured on frameworks that were setting something other than "exception" for the attribute. So now by default other than "exception" we include "javax.servlet.error.exception" and "org.springframework.web.servlet.DispatcherServlet.EXCEPTION" - the latter which is set by Spring. The list of attributes to search is configurable (the first one that is actually set with an exception is used - if any Exception exists) - the list is configurable if for some reason some other web framework sets some other attribute value for some reason.