### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/stagemonitor-benchmark/src/jmh/java/org/stagemonitor/benchmark/profiler/OptimalPerformanceProfilerMock.java
+++ b/stagemonitor-benchmark/src/jmh/java/org/stagemonitor/benchmark/profiler/OptimalPerformanceProfilerMock.java
@@ -9,6 +9,9 @@ public class OptimalPerformanceProfilerMock {
 	static List<String> signatures = new ArrayList<String>();
 	private static long dummy = 0;
 
+	private OptimalPerformanceProfilerMock() {
+	}
+
 	public static void start() {
 		dummy = System.nanoTime();
 	}

--- a/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationOptionsMarkdownExporter.java
+++ b/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationOptionsMarkdownExporter.java
@@ -10,6 +10,9 @@ import org.stagemonitor.core.configuration.ConfigurationOption;
 
 public class ConfigurationOptionsMarkdownExporter {
 
+	private ConfigurationOptionsMarkdownExporter() {
+	}
+
 	public static void main(String[] args) throws IOException {
 		final Map<String, List<ConfigurationOption<?>>> configurationOptionsByPlugin = new Configuration(StagemonitorPlugin.class).getConfigurationOptionsByCategory();
 

--- a/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationSourceExporter.java
+++ b/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationSourceExporter.java
@@ -10,6 +10,9 @@ import org.stagemonitor.core.util.JsonUtils;
 
 public class ConfigurationSourceExporter {
 
+	private ConfigurationSourceExporter() {
+	}
+
 	public static void main(String[] args) throws IOException {
 		final String json = JsonUtils.toJson(new Configuration(StagemonitorPlugin.class).getConfigurationOptionsByCategory());
 		System.out.println(json);

--- a/stagemonitor-benchmark/src/test/java/org/stagemonitor/InstrumentationPerformanceTest.java
+++ b/stagemonitor-benchmark/src/test/java/org/stagemonitor/InstrumentationPerformanceTest.java
@@ -25,6 +25,9 @@ public class InstrumentationPerformanceTest  {
 
 	private static Node node;
 
+	private InstrumentationPerformanceTest() {
+	}
+
 	public static void main(String[] args) throws Exception {
 		final Timer.Context timer = Stagemonitor.getMetric2Registry().timer(name("startElasticsearch").build()).time();
 		startElasticsearch();

--- a/stagemonitor-benchmark/stagemonitor-byte-buddy-agent/src/main/java/org/stagemonitor/instrument/ByteBuddyProfiler.java
+++ b/stagemonitor-benchmark/stagemonitor-byte-buddy-agent/src/main/java/org/stagemonitor/instrument/ByteBuddyProfiler.java
@@ -16,6 +16,9 @@ import org.stagemonitor.requestmonitor.profiler.Profiler;
 
 public class ByteBuddyProfiler {
 
+	private ByteBuddyProfiler() {
+	}
+
 	public static void premain(String agentArgs, Instrumentation inst) {
 		new AgentBuilder.Default()
 				.rebase(new ElementMatcher<TypeDescription>() {
@@ -39,6 +42,9 @@ public class ByteBuddyProfiler {
 	}
 
 	public static class ProfilingInterceptor {
+		private ProfilingInterceptor() {
+		}
+
 		@RuntimeType
 		public static Object profile(@Origin String signature, @SuperCall Callable<?> zuper) throws Exception {
 			Profiler.start(signature);

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/instrument/AgentLoader.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/instrument/AgentLoader.java
@@ -95,6 +95,9 @@ final class AgentLoader {
 		}
 	}
 
+	private AgentLoader() {
+	}
+
 	private static Class<?> getVirtualMachineClass() throws ClassNotFoundException {
 		try {
 			return AccessController.doPrivileged(new PrivilegedExceptionAction<Class<?>>() {

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/ClassUtils.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/ClassUtils.java
@@ -2,6 +2,9 @@ package org.stagemonitor.core.util;
 
 public class ClassUtils {
 
+	private ClassUtils() {
+	}
+
 	public static Class<?> forNameOrNull(String className) {
 		try {
 			return Class.forName(className);

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/IOUtils.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/IOUtils.java
@@ -14,6 +14,9 @@ public class IOUtils {
 	private static final int BUFFER_SIZE = 4096;
 	private static final Logger logger = LoggerFactory.getLogger(IOUtils.class);
 
+	private IOUtils() {
+	}
+
 	public static void copy(InputStream input, OutputStream output) throws IOException {
 		int n;
 		final byte[] buffer = new byte[BUFFER_SIZE];

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/JsonUtils.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/JsonUtils.java
@@ -37,6 +37,9 @@ public class JsonUtils {
 		MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 	}
 
+	private JsonUtils() {
+	}
+
 	public static boolean versionsMatch(Version v1, Version v2) {
 		return v1.getMajorVersion() == v2.getMajorVersion() &&
 				v1.getMinorVersion() == v2.getMinorVersion() &&

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/StringUtils.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/StringUtils.java
@@ -13,6 +13,9 @@ public class StringUtils {
 
 	public static final Pattern CAMEL_CASE = Pattern.compile("(?<=[A-Z])(?=[A-Z][a-z])|(?<=[^A-Z])(?=[A-Z])|(?<=[A-Za-z])(?=[^A-Za-z])");
 
+	private StringUtils() {
+	}
+
 	public static String removeStart(final String str, final String remove) {
 		if (remove != null && str.startsWith(remove)) {
 			return str.substring(remove.length());

--- a/stagemonitor-javaagent/src/main/java/org/stagemonitor/agent/StagemonitorAgent.java
+++ b/stagemonitor-javaagent/src/main/java/org/stagemonitor/agent/StagemonitorAgent.java
@@ -12,6 +12,9 @@ public class StagemonitorAgent {
 
 	private static boolean initialized = false;
 
+	private StagemonitorAgent() {
+	}
+
 	/**
 	 * Allows the installation of the agent via the -javaagent command line argument
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.