### PR TITLE
 Thread.run() and Runnable.run() should not be called directly

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
@@ -153,7 +153,7 @@ public final class Stagemonitor {
 		measurementSession.setEndTimestamp(System.currentTimeMillis());
 		for (Runnable onShutdownAction : onShutdownActions) {
 			try {
-				onShutdownAction.run();
+				new Thread(onShutdownAction).start();
 			} catch (RuntimeException e) {
 				logger.warn(e.getMessage(), e);
 			}

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -142,7 +142,7 @@ public class RequestMonitor {
 
 		for (Runnable onAfterRequestCallback : onAfterRequestCallbacks) {
 			try {
-				onAfterRequestCallback.run();
+				new Thread(onAfterRequestCallback).start();
 			} catch (RuntimeException e) {
 				logger.warn(e.getMessage() + " (this exception is ignored) " + info.toString(), e);
 			}
@@ -216,7 +216,7 @@ public class RequestMonitor {
 		}
 		for (Runnable onBeforeRequestCallback : onBeforeRequestCallbacks) {
 			try {
-				onBeforeRequestCallback.run();
+				new Thread(onBeforeRequestCallback).start();
 			} catch (RuntimeException e) {
 				logger.warn(e.getMessage() + " (this exception is ignored) " + info.toString(), e);
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1217 - “ Thread.run() and Runnable.run() should not be called directly”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1217
Please let me know if you have any questions.
Ayman Abdelghany.