### PR TITLE
Allow custom host name value

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/MeasurementSession.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/MeasurementSession.java
@@ -118,24 +118,4 @@ public class MeasurementSession {
 		return stringRepresentation;
 	}
 
-	public static String getNameOfLocalHost() {
-		try {
-			return InetAddress.getLocalHost().getHostName();
-		} catch (Exception e) {
-			return getHostNameFromEnv();
-		}
-	}
-
-	static String getHostNameFromEnv() {
-		// try environment properties.
-		String host = System.getenv("COMPUTERNAME");
-		if (host != null) {
-			return host;
-		}
-		host = System.getenv("HOSTNAME");
-		if (host != null) {
-			return host;
-		}
-		return null;
-	}
 }

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
@@ -230,7 +230,7 @@ public final class Stagemonitor {
 	private static void tryStartMonitoring() {
 		CorePlugin corePlugin = getConfiguration(CorePlugin.class);
 		MeasurementSession session = new MeasurementSession(corePlugin.getApplicationName(),
-				MeasurementSession.getNameOfLocalHost(), corePlugin.getInstanceName());
+				corePlugin.getHostName(), corePlugin.getInstanceName());
 		startMonitoring(session);
 	}
 

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/MeasurementSessionTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/MeasurementSessionTest.java
@@ -16,13 +16,13 @@ public class MeasurementSessionTest {
 	@Test
 	@ExcludeOnTravis
 	public void testGetHostname() {
-		assertNotNull(MeasurementSession.getNameOfLocalHost());
+		assertNotNull(CorePlugin.getNameOfLocalHost());
 	}
 
 	@Test
 	@Ignore
 	public void testGetHostnameFromEnv() {
-		assertNotNull(MeasurementSession.getHostNameFromEnv());
+		assertNotNull(CorePlugin.getHostNameFromEnv());
 	}
 
 	@Test

--- a/stagemonitor-os/src/main/java/org/stagemonitor/os/OsPlugin.java
+++ b/stagemonitor-os/src/main/java/org/stagemonitor/os/OsPlugin.java
@@ -127,7 +127,7 @@ public class OsPlugin extends StagemonitorPlugin implements StagemonitorConfigur
 		final CorePlugin corePlugin = Stagemonitor.getConfiguration(CorePlugin.class);
 		String applicationName = corePlugin.getApplicationName() != null ? corePlugin.getApplicationName() : "os";
 		String instanceName = corePlugin.getInstanceName() != null ? corePlugin.getInstanceName() : "host";
-		return new MeasurementSession(applicationName, MeasurementSession.getNameOfLocalHost(), instanceName);
+		return new MeasurementSession(applicationName, corePlugin.getHostName(), instanceName);
 	}
 
 	static ConfigurationSource getConfiguration(String[] args) {

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -198,7 +198,7 @@ public class RequestMonitor {
 
 	private synchronized void createMeasurementSession() {
 		if (Stagemonitor.getMeasurementSession().isNull()) {
-			MeasurementSession session = new MeasurementSession(corePlugin.getApplicationName(), MeasurementSession.getNameOfLocalHost(),
+			MeasurementSession session = new MeasurementSession(corePlugin.getApplicationName(), corePlugin.getHostName(),
 					corePlugin.getInstanceName());
 			Stagemonitor.setMeasurementSession(session);
 		}

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilter.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilter.java
@@ -69,7 +69,7 @@ public class HttpRequestMonitorFilter extends AbstractExclusionFilter implements
 	@Override
 	public void initInternal(FilterConfig filterConfig) throws ServletException {
 		final MeasurementSession measurementSession = new MeasurementSession(getApplicationName(filterConfig),
-				MeasurementSession.getNameOfLocalHost(), corePlugin.getInstanceName());
+				corePlugin.getHostName(), corePlugin.getInstanceName());
 		Stagemonitor.setMeasurementSession(measurementSession);
 		final ServletContext servletContext = filterConfig.getServletContext();
 		atLeastServletApi3 = servletContext.getMajorVersion() >= 3;


### PR DESCRIPTION
We need bigger flexibility for what is written in the hostname, so this patch
adds the possibility to set this via the configuration.