### PR TITLE
Widen global catch clause

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
@@ -91,8 +91,8 @@ public final class Stagemonitor {
 			logger.info("Measurement Session is initialized: " + measurementSession);
 			try {
 				start();
-			} catch (RuntimeException e) {
-				logger.warn("Error while trying to start monitoring. (this exception is ignored)", e);
+			} catch (Throwable t) {
+				logger.warn("Error while trying to start monitoring. (this exception is ignored)", t);
 			}
 		} else {
 			logger.warn("Measurement Session is not initialized: {}", measurementSession);


### PR DESCRIPTION
I'm having dependency issues with Dropwizard and couldn't see the error,
because it was swallowed above that level. So this makes it easier to debug
obscure problems.