### PR TITLE
Use a shared Dropwizard registry again

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/Metric2Registry.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/Metric2Registry.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
 
 /**
@@ -38,7 +39,7 @@ public class Metric2Registry implements Metric2Set {
 
 	public Metric2Registry(ConcurrentMap<MetricName, Metric> metrics) {
 		this.metrics = metrics;
-		this.metricRegistry = new MetricRegistry();
+		this.metricRegistry = SharedMetricRegistries.getOrCreate("stagemonitor");
 	}
 
 	/**


### PR DESCRIPTION
In systems where you have multiple reporters that all use Dropwizard it is
necessary to have a shared registry. This allows the other reporters to access
the stagemonitor registry and vice versa.