### PR TITLE
Report plain histogram metrics unscaled

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/SortedTableLogReporter.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/SortedTableLogReporter.java
@@ -272,11 +272,11 @@ public class SortedTableLogReporter extends ScheduledMetrics2Reporter {
 	private void printHistogram(String name, Histogram histogram, int maxNameLength, StringBuilder sb) {
 		sb.append(String.format("%" + maxNameLength + "s | ", name));
 		sb.append(formatCount(histogram.getCount()));
-		printSnapshot(histogram.getSnapshot(), sb);
+		printHistogramSnapshot(histogram.getSnapshot(), sb);
 		sb.append('\n');
 	}
 
-	private void printSnapshot(Snapshot snapshot, StringBuilder sb) {
+	private void printTimerSnapshot(Snapshot snapshot, StringBuilder sb) {
 		printDouble(convertDuration(snapshot.getMean()), sb);
 		printDouble(convertDuration(snapshot.getMin()), sb);
 		printDouble(convertDuration(snapshot.getMax()), sb);
@@ -288,12 +288,25 @@ public class SortedTableLogReporter extends ScheduledMetrics2Reporter {
 		printDouble(convertDuration(snapshot.get99thPercentile()), sb);
 		printDouble(convertDuration(snapshot.get999thPercentile()), sb);
 	}
+	
+	private void printHistogramSnapshot(Snapshot snapshot, StringBuilder sb) {
+		printDouble(snapshot.getMean(), sb);
+		printDouble(snapshot.getMin(), sb);
+		printDouble(snapshot.getMax(), sb);
+		printDouble(snapshot.getStdDev(), sb);
+		printDouble(snapshot.getMedian(), sb);
+		printDouble(snapshot.get75thPercentile(), sb);
+		printDouble(snapshot.get95thPercentile(), sb);
+		printDouble(snapshot.get98thPercentile(), sb);
+		printDouble(snapshot.get99thPercentile(), sb);
+		printDouble(snapshot.get999thPercentile(), sb);
+	}
 
 	private void printTimer(String name, Timer timer, int maxNameLength, StringBuilder sb) {
 		final Snapshot snapshot = timer.getSnapshot();
 		sb.append(String.format("%" + maxNameLength + "s | ", name));
 		sb.append(formatCount(timer.getCount()));
-		printSnapshot(snapshot, sb);
+		printTimerSnapshot(snapshot, sb);
 		printMetered(timer, sb);
 		sb.append('\n');
 	}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporter.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporter.java
@@ -82,7 +82,7 @@ public class InfluxDbReporter extends ScheduledMetrics2Reporter {
 			final Snapshot snapshot = hist.getSnapshot();
 			reportLine(getInfluxDbLineProtocolString(entry.getKey()),
 					"count=" + getIntegerValue(hist.getCount()) + ","
-							+ reportSnapshot(snapshot), timestamp);
+							+ reportHistogramSnapshot(snapshot), timestamp);
 		}
 	}
 
@@ -99,11 +99,11 @@ public class InfluxDbReporter extends ScheduledMetrics2Reporter {
 			final Snapshot snapshot = timer.getSnapshot();
 			reportLine(getInfluxDbLineProtocolString(entry.getKey()),
 					reportMetered(timer) + ","
-							+ reportSnapshot(snapshot), timestamp);
+							+ reportTimerSnapshot(snapshot), timestamp);
 		}
 	}
 
-	private String reportSnapshot(Snapshot snapshot) {
+	private String reportTimerSnapshot(Snapshot snapshot) {
 		return "min=" + getDuration(snapshot.getMin()) + ","
 				+ "max=" + getDuration(snapshot.getMax()) + ","
 				+ "mean=" + getDuration(snapshot.getMean()) + ","
@@ -115,6 +115,20 @@ public class InfluxDbReporter extends ScheduledMetrics2Reporter {
 				+ "p98=" + getDuration(snapshot.get98thPercentile()) + ","
 				+ "p99=" + getDuration(snapshot.get99thPercentile()) + ","
 				+ "p999=" + getDuration(snapshot.get999thPercentile());
+	}
+	
+	private String reportHistogramSnapshot(Snapshot snapshot) {
+		return "min=" + snapshot.getMin() + ","
+				+ "max=" + snapshot.getMax() + ","
+				+ "mean=" + snapshot.getMean() + ","
+				+ "p50=" + snapshot.getMedian() + ","
+				+ "std=" + snapshot.getStdDev() + ","
+				+ "p25=" + snapshot.getValue(0.25) + ","
+				+ "p75=" + snapshot.get75thPercentile() + ","
+				+ "p95=" + snapshot.get95thPercentile() + ","
+				+ "p98=" + snapshot.get98thPercentile() + ","
+				+ "p99=" + snapshot.get99thPercentile() + ","
+				+ "p999=" + snapshot.get999thPercentile();
 	}
 
 	private String reportMetered(Metered metered) {

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/Metric2RegistryModule.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/Metric2RegistryModule.java
@@ -143,7 +143,7 @@ public class Metric2RegistryModule extends Module {
 		public void writeValues(Histogram histogram, JsonGenerator jg) throws IOException {
 			final Snapshot snapshot = histogram.getSnapshot();
 			jg.writeNumberField("count", histogram.getCount());
-			writeSnapshot(snapshot, jg);
+			writeHistogramSnapshot(snapshot, jg);
 		}
 	}
 
@@ -156,11 +156,11 @@ public class Metric2RegistryModule extends Module {
 	private class TimerValueWriter implements ValueWriter<Timer> {
 		public void writeValues(Timer timer, JsonGenerator jg) throws IOException {
 			writeMetered(timer, jg);
-			writeSnapshot(timer.getSnapshot(), jg);
+			writeTimerSnapshot(timer.getSnapshot(), jg);
 		}
 	}
 
-	private void writeSnapshot(Snapshot snapshot, JsonGenerator jg) throws IOException {
+	private void writeTimerSnapshot(Snapshot snapshot, JsonGenerator jg) throws IOException {
 		writeDoubleUnlessNaN(jg, "min", convertDuration(snapshot.getMin()));
 		writeDoubleUnlessNaN(jg, "max", convertDuration(snapshot.getMax()));
 		writeDoubleUnlessNaN(jg, "mean", convertDuration(snapshot.getMean()));
@@ -172,6 +172,20 @@ public class Metric2RegistryModule extends Module {
 		writeDoubleUnlessNaN(jg, "p98", convertDuration(snapshot.get98thPercentile()));
 		writeDoubleUnlessNaN(jg, "p99", convertDuration(snapshot.get99thPercentile()));
 		writeDoubleUnlessNaN(jg, "p999", convertDuration(snapshot.get999thPercentile()));
+	}
+	
+	private void writeHistogramSnapshot(Snapshot snapshot, JsonGenerator jg) throws IOException {
+		writeDoubleUnlessNaN(jg, "min", snapshot.getMin());
+		writeDoubleUnlessNaN(jg, "max", snapshot.getMax());
+		writeDoubleUnlessNaN(jg, "mean", snapshot.getMean());
+		writeDoubleUnlessNaN(jg, "p50", snapshot.getMedian());
+		writeDoubleUnlessNaN(jg, "std", snapshot.getStdDev());
+		writeDoubleUnlessNaN(jg, "p25", snapshot.getValue(0.25));
+		writeDoubleUnlessNaN(jg, "p75", snapshot.get75thPercentile());
+		writeDoubleUnlessNaN(jg, "p95", snapshot.get95thPercentile());
+		writeDoubleUnlessNaN(jg, "p98", snapshot.get98thPercentile());
+		writeDoubleUnlessNaN(jg, "p99", snapshot.get99thPercentile());
+		writeDoubleUnlessNaN(jg, "p999", snapshot.get999thPercentile());
 	}
 
 	private void writeMetered(Metered metered, JsonGenerator jg) throws IOException {

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/MetricsReporterTestHelper.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/MetricsReporterTestHelper.java
@@ -29,7 +29,7 @@ public class MetricsReporterTestHelper {
 	}
 
 	public static Snapshot snapshot(double mean) {
-		return snapshot(mean, 2L, 4L, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0);
+		return snapshot(mean, 200L, 400L, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, 1100.0);
 	}
 
 	public static Snapshot snapshot(double mean, long max, long min, double stdDev, double p50, double p75, double p95,

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/SortedTableLogReporterTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/SortedTableLogReporterTest.java
@@ -20,6 +20,9 @@ import org.stagemonitor.core.metrics.metrics2.MetricName;
 
 public class SortedTableLogReporterTest extends MetricsReporterTestHelper {
 
+	private static final TimeUnit DURATION_UNIT = TimeUnit.MICROSECONDS;
+	private static final double DURATION_FACTOR = 1.0 / DURATION_UNIT.toNanos(1);
+	
 	private Logger logger;
 	private SortedTableLogReporter reporter;
 
@@ -30,7 +33,7 @@ public class SortedTableLogReporterTest extends MetricsReporterTestHelper {
 				.forRegistry(mock(Metric2Registry.class))
 				.log(logger)
 				.convertRatesTo(TimeUnit.SECONDS)
-				.convertDurationsTo(TimeUnit.NANOSECONDS)
+				.convertDurationsTo(DURATION_UNIT)
 				.formattedFor(Locale.US)
 				.build();
 	}
@@ -82,14 +85,14 @@ public class SortedTableLogReporterTest extends MetricsReporterTestHelper {
 				"\n" +
 				"-- Histograms ------------------------------------------------------------------\n" +
 				"name            | count     | mean      | min       | max       | stddev    | p50       | p75       | p95       | p98       | p99       | p999      |\n" +
-				"test.histogram2 |         1 |      4.00 |      4.00 |      2.00 |      5.00 |      6.00 |      7.00 |      8.00 |      9.00 |     10.00 |     11.00 | \n" +
-				" test.histogram |         1 |      3.00 |      4.00 |      2.00 |      5.00 |      6.00 |      7.00 |      8.00 |      9.00 |     10.00 |     11.00 | \n" +
+				"test.histogram2 |         1 |    400.00 |    400.00 |    200.00 |    500.00 |    600.00 |    700.00 |    800.00 |    900.00 |  1,000.00 |  1,100.00 | \n" +
+				" test.histogram |         1 |    300.00 |    400.00 |    200.00 |    500.00 |    600.00 |    700.00 |    800.00 |    900.00 |  1,000.00 |  1,100.00 | \n" +
 				"\n" +
 				"\n");
 	}
 
 	private FluentMap<MetricName, Histogram> testHistograms() {
-		return map(name("test.histogram").build(), histogram(3.0)).add(name("test.histogram2").build(), histogram(4.0));
+		return map(name("test.histogram").build(), histogram(300.0)).add(name("test.histogram2").build(), histogram(400.0));
 	}
 
 	@Test
@@ -105,8 +108,8 @@ public class SortedTableLogReporterTest extends MetricsReporterTestHelper {
 				"\n" +
 				"-- Meters ----------------------------------------------------------------------\n" +
 				"name                | count     | mean_rate | m1_rate   | m5_rate   | m15_rate  | rate_unit     | duration_unit\n" +
-				"        test.meter2 |         2 |      2.00 |      3.00 |      4.00 |      5.00 | second        | nanoseconds\n" +
-				"test.meter1,foo=bar |         1 |      2.00 |      3.00 |      4.00 |      5.00 | second        | nanoseconds\n" +
+				"        test.meter2 |         2 |      2.00 |      3.00 |      4.00 |      5.00 | second        | microseconds\n" +
+				"test.meter1,foo=bar |         1 |      2.00 |      3.00 |      4.00 |      5.00 | second        | microseconds\n" +
 				"\n" +
 				"\n");
 	}
@@ -118,15 +121,15 @@ public class SortedTableLogReporterTest extends MetricsReporterTestHelper {
 				map(),
 				map(),
 				map(),
-				map(name("timer1").build(), timer(4)).add(name("timer2").build(), timer(2)).add(name("timer3").build(), timer(3)));
+				map(name("timer1").build(), timer(400)).add(name("timer2").build(), timer(200)).add(name("timer3").build(), timer(300)));
 
 		verify(logger).info("Metrics ========================================================================\n" +
 				"\n" +
 				"-- Timers ----------------------------------------------------------------------\n" +
 				"name   | count     | mean      | min       | max       | stddev    | p50       | p75       | p95       | p98       | p99       | p999      | mean_rate | m1_rate   | m5_rate   | m15_rate  | rate_unit     | duration_unit\n" +
-				"timer1 |         1 |      4.00 |      4.00 |      2.00 |      5.00 |      6.00 |      7.00 |      8.00 |      9.00 |     10.00 |     11.00 |      2.00 |      3.00 |      4.00 |      5.00 | second        | nanoseconds\n" +
-				"timer3 |         1 |      3.00 |      4.00 |      2.00 |      5.00 |      6.00 |      7.00 |      8.00 |      9.00 |     10.00 |     11.00 |      2.00 |      3.00 |      4.00 |      5.00 | second        | nanoseconds\n" +
-				"timer2 |         1 |      2.00 |      4.00 |      2.00 |      5.00 |      6.00 |      7.00 |      8.00 |      9.00 |     10.00 |     11.00 |      2.00 |      3.00 |      4.00 |      5.00 | second        | nanoseconds\n" +
+				"timer1 |         1 |      0.40 |      0.40 |      0.20 |      0.50 |      0.60 |      0.70 |      0.80 |      0.90 |      1.00 |      1.10 |      2.00 |      3.00 |      4.00 |      5.00 | second        | microseconds\n" +
+				"timer3 |         1 |      0.30 |      0.40 |      0.20 |      0.50 |      0.60 |      0.70 |      0.80 |      0.90 |      1.00 |      1.10 |      2.00 |      3.00 |      4.00 |      5.00 | second        | microseconds\n" +
+				"timer2 |         1 |      0.20 |      0.40 |      0.20 |      0.50 |      0.60 |      0.70 |      0.80 |      0.90 |      1.00 |      1.10 |      2.00 |      3.00 |      4.00 |      5.00 | second        | microseconds\n" +
 				"\n" +
 				"\n");
 	}

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/ElasticsearchReporterTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/ElasticsearchReporterTest.java
@@ -45,6 +45,9 @@ import static org.stagemonitor.core.metrics.metrics2.MetricName.name;
 
 public class ElasticsearchReporterTest {
 
+	private static final TimeUnit DURATION_UNIT = TimeUnit.MICROSECONDS;
+	private static final double DURATION_FACTOR = 1.0 / DURATION_UNIT.toNanos(1);
+	
 	private ElasticsearchReporter elasticsearchReporter;
 	private long timestamp;
 	private ByteArrayOutputStream out;
@@ -73,7 +76,7 @@ public class ElasticsearchReporterTest {
 		corePlugin = mock(CorePlugin.class);
 		registry = new Metric2Registry();
 		elasticsearchReporter = ElasticsearchReporter.forRegistry(registry, corePlugin)
-				.convertDurationsTo(TimeUnit.NANOSECONDS)
+				.convertDurationsTo(DURATION_UNIT)
 				.globalTags(singletonMap("app", "test"))
 				.httpClient(httpClient)
 				.clock(clock)
@@ -243,7 +246,7 @@ public class ElasticsearchReporterTest {
 		elasticsearchReporter.reportMetrics(
 				metricNameMap(Gauge.class),
 				metricNameMap(Counter.class),
-				metricNameMap(name("histogram").build(), histogram(4)),
+				metricNameMap(name("histogram").build(), histogram(400)),
 				metricNameMap(Meter.class),
 				metricNameMap(Timer.class));
 
@@ -251,17 +254,17 @@ public class ElasticsearchReporterTest {
 						.add("name", "histogram")
 						.add("app", "test")
 						.add("count", 1)
-						.add("max", 2.0)
-						.add("mean", 4.0)
-						.add("p50", 6.0)
-						.add("min", 4.0)
+						.add("max", 200.0)
+						.add("mean", 400.0)
+						.add("p50", 600.0)
+						.add("min", 400.0)
 						.add("p25", 0.0)
-						.add("p75", 7.0)
-						.add("p95", 8.0)
-						.add("p98", 9.0)
-						.add("p99", 10.0)
-						.add("p999", 11.0)
-						.add("std", 5.0),
+						.add("p75", 700.0)
+						.add("p95", 800.0)
+						.add("p98", 900.0)
+						.add("p99", 1000.0)
+						.add("p999", 1100.0)
+						.add("std", 500.0),
 				asMap(out));
 	}
 
@@ -292,7 +295,7 @@ public class ElasticsearchReporterTest {
 				metricNameMap(Counter.class),
 				metricNameMap(Histogram.class),
 				metricNameMap(Meter.class),
-				metricNameMap(name("response_time").build(), timer(4)));
+				metricNameMap(name("response_time").build(), timer(400)));
 
 		assertEquals(map("@timestamp", timestamp, Object.class)
 						.add("name", "response_time")
@@ -302,17 +305,17 @@ public class ElasticsearchReporterTest {
 						.add("m1_rate", 3.0)
 						.add("m5_rate", 4.0)
 						.add("mean_rate", 2.0)
-						.add("max", 2.0)
-						.add("mean", 4.0)
-						.add("p50", 6.0)
-						.add("min", 4.0)
-						.add("p25", 0.0)
-						.add("p75", 7.0)
-						.add("p95", 8.0)
-						.add("p98", 9.0)
-						.add("p99", 10.0)
-						.add("p999", 11.0)
-						.add("std", 5.0),
+						.add("max", 200.0 * DURATION_FACTOR)
+						.add("mean", 400.0 * DURATION_FACTOR)
+						.add("p50", 600.0 * DURATION_FACTOR)
+						.add("min", 400.0 * DURATION_FACTOR)
+						.add("p25", 0.0 * DURATION_FACTOR)
+						.add("p75", 700.0 * DURATION_FACTOR)
+						.add("p95", 800.0 * DURATION_FACTOR)
+						.add("p98", 900.0 * DURATION_FACTOR)
+						.add("p99", 1000.0 * DURATION_FACTOR)
+						.add("p999", 1100.0 * DURATION_FACTOR)
+						.add("std", 500.0 * DURATION_FACTOR),
 				asMap(out));
 	}
 

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporterTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporterTest.java
@@ -33,6 +33,8 @@ import static org.stagemonitor.core.metrics.metrics2.MetricName.name;
 
 public class InfluxDbReporterTest {
 
+	private static final TimeUnit DURATION_UNIT = TimeUnit.MICROSECONDS;
+
 	private InfluxDbReporter influxDbReporter;
 	private HttpClient httpClient;
 	private long timestamp;
@@ -48,7 +50,7 @@ public class InfluxDbReporterTest {
 		when(corePlugin.getInfluxDbDb()).thenReturn("stm");
 		influxDbReporter = InfluxDbReporter.forRegistry(new Metric2Registry(), corePlugin)
 				.convertRatesTo(TimeUnit.SECONDS)
-				.convertDurationsTo(TimeUnit.NANOSECONDS)
+				.convertDurationsTo(DURATION_UNIT)
 				.globalTags(singletonMap("app", "test"))
 				.httpClient(httpClient)
 				.clock(clock)
@@ -138,12 +140,12 @@ public class InfluxDbReporterTest {
 		influxDbReporter.reportMetrics(
 				metricNameMap(Gauge.class),
 				metricNameMap(Counter.class),
-				metricNameMap(name("histogram").build(), histogram(4)),
+				metricNameMap(name("histogram").build(), histogram(400)),
 				metricNameMap(Meter.class),
 				metricNameMap(Timer.class));
 
 		verify(httpClient).send(eq("POST"), eq("http://localhost:8086/write?precision=ms&db=stm"),
-				eq(singletonList(format("histogram,app=test count=1i,min=4.0,max=2.0,mean=4.0,p50=6.0,std=5.0,p25=0.0,p75=7.0,p95=8.0,p98=9.0,p99=10.0,p999=11.0 %d", timestamp))));
+				eq(singletonList(format("histogram,app=test count=1i,min=400,max=200,mean=400.0,p50=600.0,std=500.0,p25=0.0,p75=700.0,p95=800.0,p98=900.0,p99=1000.0,p999=1100.0 %d", timestamp))));
 	}
 
 	@Test
@@ -166,10 +168,10 @@ public class InfluxDbReporterTest {
 				metricNameMap(Counter.class),
 				metricNameMap(Histogram.class),
 				metricNameMap(Meter.class),
-				metricNameMap(name("response_time").build(), timer(4)));
+				metricNameMap(name("response_time").build(), timer(400)));
 
 		verify(httpClient).send(eq("POST"), eq("http://localhost:8086/write?precision=ms&db=stm"),
-				eq(singletonList(format("response_time,app=test count=1i,m1_rate=3.0,m5_rate=4.0,m15_rate=5.0,mean_rate=2.0,min=4.0,max=2.0,mean=4.0,p50=6.0,std=5.0,p25=0.0,p75=7.0,p95=8.0,p98=9.0,p99=10.0,p999=11.0 %d", timestamp))));
+				eq(singletonList(format("response_time,app=test count=1i,m1_rate=3.0,m5_rate=4.0,m15_rate=5.0,mean_rate=2.0,min=0.4,max=0.2,mean=0.4,p50=0.6,std=0.5,p25=0.0,p75=0.7000000000000001,p95=0.8,p98=0.9,p99=1.0,p999=1.1 %d", timestamp))));
 	}
 
 	@Test


### PR DESCRIPTION
Here is a fix for #184. This will report plain histogram metrics without treating the values as time values that need a conversion to another time unit.

Please feel free to include this. It fixes my issue but I'm not quite sure whether changing this matches the project's goals.