### PR TITLE
Handle async servlets correctly

### DIFF
--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
@@ -1,5 +1,6 @@
 package org.stagemonitor.requestmonitor;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -49,10 +50,15 @@ public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 		return methodExecution.execute();
 	}
 
-    @Override
-    public ListenableFuture<Object> executeAsync() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
+	@Override
+	public ListenableFuture<Object> executeAsync() {
+		try {
+			return Futures.immediateFuture(methodExecution.execute());
+		}
+		catch (Exception e) {
+			return Futures.immediateFailedFuture(e);
+		}
+	}
 
 	@Override
 	public void onPostExecute(RequestMonitor.RequestInformation<RequestTrace> requestTrace) {

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
@@ -1,5 +1,6 @@
 package org.stagemonitor.requestmonitor;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -47,6 +48,11 @@ public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 	public Object execute() throws Exception {
 		return methodExecution.execute();
 	}
+
+    @Override
+    public ListenableFuture<Object> executeAsync() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
 
 	@Override
 	public void onPostExecute(RequestMonitor.RequestInformation<RequestTrace> requestTrace) {

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
@@ -1,5 +1,7 @@
 package org.stagemonitor.requestmonitor;
 
+import com.google.common.util.concurrent.ListenableFuture;
+
 public interface MonitoredRequest<T extends RequestTrace> {
 
 	/**
@@ -33,6 +35,8 @@ public interface MonitoredRequest<T extends RequestTrace> {
 	 * @throws Exception
 	 */
 	Object execute() throws Exception;
+
+	ListenableFuture<Object> executeAsync();
 
 	/**
 	 * Implement this method to do actions after the execution context

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -191,36 +191,31 @@ public class RequestMonitor {
 		}
 	}
 
-	public <T extends RequestTrace> ListenableFuture<RequestInformation<T>> monitorAsync(MonitoredRequest<T> monitoredRequest) { //throws Exception {
-		//try {
-			monitorStart(monitoredRequest);
-			final RequestInformation<T> info = (RequestInformation<T>) request.get();
+	public <T extends RequestTrace> ListenableFuture<RequestInformation<T>> monitorAsync(MonitoredRequest<T> monitoredRequest) {
+		monitorStart(monitoredRequest);
+		final RequestInformation<T> info = (RequestInformation<T>) request.get();
 
-            final SettableFuture<RequestInformation<T>> future = SettableFuture.create();
+		final SettableFuture<RequestInformation<T>> future = SettableFuture.create();
 
-            Futures.addCallback(monitoredRequest.executeAsync(), new FutureCallback<Object>() {
-                @Override
-                public void onSuccess(Object f) {
-                    info.executionResult = f;
-                    request.set(info);
-                    monitorStop();
-                    future.set(info);
-                }
+		Futures.addCallback(monitoredRequest.executeAsync(), new FutureCallback<Object>() {
+			@Override
+			public void onSuccess(Object f) {
+				info.executionResult = f;
+				request.set(info);
+				monitorStop();
+				future.set(info);
+			}
 
-                @Override
-                public void onFailure(Throwable thrwbl) {
-                    info.executionResult = thrwbl;
-                    request.set(info);
-                    monitorStop();
-                    future.setException(thrwbl);
-                }
-            });
+			@Override
+			public void onFailure(Throwable thrwbl) {
+				info.executionResult = thrwbl;
+				request.set(info);
+				monitorStop();
+				future.setException(thrwbl);
+			}
+		});
 
-            return future;
-		//} catch (Exception e) {
-		//	recordException(e);
-		//	throw e;
-		//}
+		return future;
 	}
 
 	public void recordException(Exception e) {

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
@@ -1,5 +1,9 @@
 package org.stagemonitor.web.monitor;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import java.io.IOException;
 import org.stagemonitor.core.Stagemonitor;
 import org.stagemonitor.core.configuration.Configuration;
 import org.stagemonitor.core.metrics.metrics2.Metric2Registry;
@@ -22,7 +26,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.regex.Pattern;
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -161,6 +168,45 @@ public class MonitoredHttpRequest implements MonitoredRequest<HttpRequestTrace> 
 		return null;
 	}
 
+	public ListenableFuture<Object> executeAsync() {
+        try {
+            filterChain.doFilter(httpServletRequest, responseWrapper);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+
+        if (httpServletRequest.isAsyncStarted()) {
+            final SettableFuture<Object> future = SettableFuture.create();
+            httpServletRequest.getAsyncContext().addListener(new AsyncListener() {
+                @Override
+                public void onComplete(AsyncEvent ae) throws IOException
+                {
+                    future.set(null);
+                }
+
+                @Override
+                public void onTimeout(AsyncEvent ae) throws IOException
+                {
+                    future.set(null);
+                }
+
+                @Override
+                public void onError(AsyncEvent ae) throws IOException
+                {
+                    future.setException(ae.getThrowable());
+                }
+
+                @Override
+                public void onStartAsync(AsyncEvent ae) throws IOException
+                {
+                }
+            });
+            return future;
+        } else {
+            return Futures.immediateFuture(null);
+        }
+	}
+
 	@Override
 	public void onPostExecute(RequestMonitor.RequestInformation<HttpRequestTrace> info) {
 		HttpRequestTrace request = info.getRequestTrace();
@@ -195,7 +241,7 @@ public class MonitoredHttpRequest implements MonitoredRequest<HttpRequestTrace> 
 				break;
 			}
 		}
-		
+
 		request.setBytesWritten(responseWrapper.getContentLength());
 
 		// get the parameters after the execution and not on creation, because that could lead to wrong decoded

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
@@ -172,7 +172,7 @@ public class MonitoredHttpRequest implements MonitoredRequest<HttpRequestTrace> 
 	public ListenableFuture<Object> executeAsync() {
 		try {
 			filterChain.doFilter(httpServletRequest, responseWrapper);
-		} catch (IOException|ServletException e) {
+		} catch (Exception e) {
 			return Futures.immediateFailedFuture(e);
 		}
 

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilter.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilter.java
@@ -116,37 +116,30 @@ public class HttpRequestMonitorFilter extends AbstractExclusionFilter implements
 			httpServletResponseBufferWrapper = new HttpServletResponseBufferWrapper(response);
 			responseWrapper = new StatusExposingByteCountingServletResponse(httpServletResponseBufferWrapper);
 		} else {
-            httpServletResponseBufferWrapper = null;
+			httpServletResponseBufferWrapper = null;
 			responseWrapper = new StatusExposingByteCountingServletResponse(response);
 		}
 
-		//try {
-            final ListenableFuture<RequestMonitor.RequestInformation<HttpRequestTrace>> future =
-                    monitorRequestAsync(filterChain, request, responseWrapper);
+		final ListenableFuture<RequestMonitor.RequestInformation<HttpRequestTrace>> future =
+				monitorRequestAsync(filterChain, request, responseWrapper);
 
-            if (isInjectContentToHtml(request)) {
-                Futures.addCallback(future, new FutureCallback<RequestMonitor.RequestInformation<HttpRequestTrace>>()
-                {
-                    @Override
-                    public void onSuccess(RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation)
-                    {
-                        try {
-                            injectHtml(response, request, httpServletResponseBufferWrapper, requestInformation);
-                        } catch (IOException e) {
-                            //???
-                        }
-                    }
+		if (isInjectContentToHtml(request)) {
+			Futures.addCallback(future, new FutureCallback<RequestMonitor.RequestInformation<HttpRequestTrace>>() {
+				@Override
+				public void onSuccess(RequestMonitor.RequestInformation<HttpRequestTrace> requestInformation) {
+					try {
+						injectHtml(response, request, httpServletResponseBufferWrapper, requestInformation);
+					} catch (IOException e) {
+						//???
+					}
+				}
 
-                    @Override
-                    public void onFailure(Throwable e)
-                    {
-                        //???
-                    }
-                });
-            }
-		//} catch (Exception e) {
-		//	handleException(e);
-		//}
+				@Override
+				public void onFailure(Throwable e) {
+					//???
+				}
+			});
+		}
 	}
 
 	private boolean isInjectContentToHtml(HttpServletRequest httpServletRequest) {

--- a/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
+++ b/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
@@ -1,5 +1,7 @@
 package org.stagemonitor.web.monitor.filter;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -63,6 +65,17 @@ public class HttpRequestMonitorFilterTest {
 				when(requestTrace.getName()).thenReturn("testName");
 				when(requestInformation.getRequestTrace()).thenReturn(requestTrace);
 				return requestInformation;
+			}
+		});
+		when(requestMonitor.monitorAsync(any(MonitoredRequest.class))).then(new Answer<ListenableFuture<RequestMonitor.RequestInformation<?>>>() {
+			@Override
+			public ListenableFuture<RequestMonitor.RequestInformation<?>> answer(InvocationOnMock invocation) throws Throwable {
+				MonitoredRequest<?> request = (MonitoredRequest<?>) invocation.getArguments()[0];
+				request.execute();
+				when(requestTrace.toJson()).thenReturn("");
+				when(requestTrace.getName()).thenReturn("testName");
+				when(requestInformation.getRequestTrace()).thenReturn(requestTrace);
+				return Futures.immediateFuture(requestInformation);
 			}
 		});
 


### PR DESCRIPTION
This should resolve issue #183.

There's only one issue left to solve, but it's not something I can figure out myself, and that is in HttpRequestMonitorFilter what do we do if the inject fails with an Exception. We can't chain it up the stack, as we might not be in the containers worker thread, and I'm not entirely sure we can send a 500 error to the response as that may be invalid (in a Broken pipe situation) or have a partially written response.