### PR TITLE
Update Async requests implementation

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
@@ -81,7 +81,7 @@ public final class Stagemonitor {
 			}
 		} else {
 			doStartMonitoring();
-			return new CompletedFuture<Void>(null);
+			return new CompletedFuture<Void>();
 		}
 	}
 

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/configuration/source/PropertyFileConfigurationSource.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/configuration/source/PropertyFileConfigurationSource.java
@@ -124,12 +124,19 @@ public final class PropertyFileConfigurationSource extends AbstractConfiguration
 			try {
 				URL resource = getClass().getClassLoader().getResource(location);
 				if (resource == null) {
-					resource = new URL("file://" + location);
+					String protocol = "file://";
+					if (location.charAt(0) != '/') {
+						//fix issue with tests on Windows detecting the drive letter
+						//as the URL's authority
+						protocol = "file:///";
+					}
+					resource = new URL(protocol + location);
 				}
 				if (!"file".equals(resource.getProtocol())) {
 					throw new IOException("Saving to property files inside a war, ear or jar is not possible.");
 				}
-				File file = new File(resource.toURI());
+				java.net.URI u = resource.toURI();
+				File file = new File(u);
 				final FileOutputStream out = new FileOutputStream(file);
 				properties.store(out, null);
 				out.flush();

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/CompletedFuture.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/CompletedFuture.java
@@ -1,37 +1,15 @@
 package org.stagemonitor.core.util;
 
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-public class CompletedFuture<T> implements Future<T> {
-	private final T result;
+public class CompletedFuture<T> extends SettableFuture<T> {
+	public CompletedFuture() {
+		set(null);
+	}
 
 	public CompletedFuture(final T result) {
-		this.result = result;
+		set(result);
 	}
 
-	@Override
-	public boolean cancel(final boolean b) {
-		return false;
-	}
-
-	@Override
-	public boolean isCancelled() {
-		return false;
-	}
-
-	@Override
-	public boolean isDone() {
-		return true;
-	}
-
-	@Override
-	public T get() {
-		return this.result;
-	}
-
-	@Override
-	public T get(final long l, final TimeUnit timeUnit) {
-		return get();
+	public CompletedFuture(final Throwable exception) {
+		setException(exception);
 	}
 }

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/ListenableFuture.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/ListenableFuture.java
@@ -1,0 +1,12 @@
+package org.stagemonitor.core.util;
+
+import java.util.concurrent.Future;
+
+public interface ListenableFuture<T> extends Future<T> {
+	public void addCallback(FutureCallback<T> callback);
+
+	public static interface FutureCallback<T> {
+		public void success(T t);
+		public void failure(Throwable t);
+	}
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/SettableFuture.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/SettableFuture.java
@@ -1,0 +1,134 @@
+package org.stagemonitor.core.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SettableFuture<T> implements ListenableFuture<T> {
+	private List<FutureCallback<T>> callbacks = null;
+	private volatile boolean cancelled = false;
+	private volatile boolean done = false;
+
+	private T result;
+	private Throwable exception;
+
+	@Override
+	public synchronized void addCallback(FutureCallback<T> callback) {
+		if (!done) {
+			if (this.callbacks == null) {
+				this.callbacks = new ArrayList<FutureCallback<T>>();
+			}
+			this.callbacks.add(callback);
+		} else {
+			executeCallback(callback);
+		}
+	}
+
+	@Override
+	public synchronized boolean cancel(boolean mayInterruptIfRunning) {
+		if (!done && !cancelled) {
+			cancelled = true;
+            exception = new CancellationException();
+			notify();
+            executeCallbacks();
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public synchronized boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public synchronized boolean isDone() {
+		return done;
+	}
+
+	private T getResult() throws ExecutionException {
+		if (this.exception != null) {
+			throw new ExecutionException(this.exception);
+		} else {
+			return result;
+		}
+	}
+
+	@Override
+	public T get() throws InterruptedException, ExecutionException {
+		if (!done && !cancelled) {
+			synchronized (this) {
+				while (!done && !cancelled) {
+					wait();
+				}
+			}
+		}
+
+		if (done) {
+			return getResult();
+		} else if (cancelled) {
+			throw new CancellationException();
+		} else {
+			throw new ExecutionException(new RuntimeException("Unknown SettableFuture error"));
+		}
+	}
+
+	@Override
+	public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+		if (done) {
+			return getResult();
+		}
+
+		synchronized (this) {
+			wait(unit.toMillis(timeout));
+			if (done) {
+				return get();
+			} else {
+				throw new TimeoutException();
+			}
+		}
+	}
+
+	public synchronized boolean set(T result) {
+		if (!done && !cancelled) {
+			this.result = result;
+			this.done = true;
+			notify();
+			executeCallbacks();
+            return true;
+		}
+        return false;
+	}
+
+	public synchronized boolean setException(Throwable exception) {
+		if (!done && !cancelled) {
+			this.exception = exception;
+			this.done = true;
+			notify();
+			executeCallbacks();
+            return true;
+		}
+        return false;
+	}
+
+	private void executeCallbacks() {
+		if (callbacks == null) {
+			return;
+		}
+		for (FutureCallback<T> callback : callbacks) {
+			executeCallback(callback);
+		}
+		callbacks = null;
+	}
+
+	private void executeCallback(FutureCallback<T> callback) {
+		if (this.exception != null) {
+			callback.failure(this.exception);
+		} else {
+			callback.success(this.result);
+		}
+	}
+}

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
@@ -1,12 +1,12 @@
 package org.stagemonitor.requestmonitor;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import org.stagemonitor.core.configuration.Configuration;
+import org.stagemonitor.core.util.CompletedFuture;
+import org.stagemonitor.core.util.ListenableFuture;
 
 public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 
@@ -53,10 +53,10 @@ public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 	@Override
 	public ListenableFuture<Object> executeAsync() {
 		try {
-			return Futures.immediateFuture(methodExecution.execute());
+			return new CompletedFuture<Object>(methodExecution.execute());
 		}
 		catch (Exception e) {
-			return Futures.immediateFailedFuture(e);
+			return new CompletedFuture<Object>(e);
 		}
 	}
 

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
@@ -46,12 +46,7 @@ public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 	}
 
 	@Override
-	public Object execute() throws Exception {
-		return methodExecution.execute();
-	}
-
-	@Override
-	public ListenableFuture<Object> executeAsync() {
+	public ListenableFuture<Object> execute() {
 		try {
 			return new CompletedFuture<Object>(methodExecution.execute());
 		}

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
@@ -34,9 +34,7 @@ public interface MonitoredRequest<T extends RequestTrace> {
 	 * @return the result of the execution
 	 * @throws Exception
 	 */
-	Object execute() throws Exception;
-
-	ListenableFuture<Object> executeAsync();
+	ListenableFuture<Object> execute();
 
 	/**
 	 * Implement this method to do actions after the execution context

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredRequest.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.requestmonitor;
 
-import com.google.common.util.concurrent.ListenableFuture;
+import org.stagemonitor.core.util.ListenableFuture;
 
 public interface MonitoredRequest<T extends RequestTrace> {
 

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -18,11 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
-import com.google.common.base.Function;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.core.CorePlugin;
@@ -35,6 +30,9 @@ import org.stagemonitor.core.metrics.metrics2.MetricName;
 import org.stagemonitor.core.util.ClassUtils;
 import org.stagemonitor.core.util.CompletedFuture;
 import org.stagemonitor.core.util.ExecutorUtils;
+import org.stagemonitor.core.util.ListenableFuture;
+import org.stagemonitor.core.util.ListenableFuture.FutureCallback;
+import org.stagemonitor.core.util.SettableFuture;
 import org.stagemonitor.core.util.StringUtils;
 import org.stagemonitor.requestmonitor.profiler.CallStackElement;
 import org.stagemonitor.requestmonitor.profiler.Profiler;
@@ -195,27 +193,28 @@ public class RequestMonitor {
 		monitorStart(monitoredRequest);
 		final RequestInformation<T> info = (RequestInformation<T>) request.get();
 
-		final SettableFuture<RequestInformation<T>> future = SettableFuture.create();
+		final SettableFuture<RequestInformation<T>> returnFuture = new SettableFuture<RequestInformation<T>>();
+		ListenableFuture<Object> future = monitoredRequest.executeAsync();
 
-		Futures.addCallback(monitoredRequest.executeAsync(), new FutureCallback<Object>() {
+		future.addCallback(new FutureCallback<Object>() {
 			@Override
-			public void onSuccess(Object f) {
+			public void success(Object f) {
 				info.executionResult = f;
 				request.set(info);
 				monitorStop();
-				future.set(info);
+				returnFuture.set(info);
 			}
 
 			@Override
-			public void onFailure(Throwable thrwbl) {
+			public void failure(Throwable thrwbl) {
 				info.executionResult = thrwbl;
 				request.set(info);
 				monitorStop();
-				future.setException(thrwbl);
+				returnFuture.setException(thrwbl);
 			}
 		});
 
-		return future;
+		return returnFuture;
 	}
 
 	public void recordException(Exception e) {

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/RequestMonitor.java
@@ -177,15 +177,9 @@ public class RequestMonitor {
 
 	public <T extends RequestTrace> RequestInformation<T> monitor(MonitoredRequest<T> monitoredRequest) throws Exception {
 		try {
-			monitorStart(monitoredRequest);
-			final RequestInformation<T> info = (RequestInformation<T>) request.get();
-			info.executionResult = monitoredRequest.execute();
-			return info;
+			return monitorAsync(monitoredRequest).get();
 		} catch (Exception e) {
-			recordException(e);
 			throw e;
-		} finally {
-			monitorStop();
 		}
 	}
 
@@ -194,7 +188,7 @@ public class RequestMonitor {
 		final RequestInformation<T> info = (RequestInformation<T>) request.get();
 
 		final SettableFuture<RequestInformation<T>> returnFuture = new SettableFuture<RequestInformation<T>>();
-		ListenableFuture<Object> future = monitoredRequest.executeAsync();
+		ListenableFuture<Object> future = monitoredRequest.execute();
 
 		future.addCallback(new FutureCallback<Object>() {
 			@Override

--- a/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
+++ b/stagemonitor-web/src/main/java/org/stagemonitor/web/monitor/MonitoredHttpRequest.java
@@ -162,13 +162,7 @@ public class MonitoredHttpRequest implements MonitoredRequest<HttpRequestTrace> 
 	}
 
 	@Override
-	public Object execute() throws Exception {
-		filterChain.doFilter(httpServletRequest, responseWrapper);
-		return null;
-	}
-
-	@Override
-	public ListenableFuture<Object> executeAsync() {
+	public ListenableFuture<Object> execute() {
 		try {
 			filterChain.doFilter(httpServletRequest, responseWrapper);
 		} catch (Exception e) {

--- a/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
+++ b/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/filter/HttpRequestMonitorFilterTest.java
@@ -1,7 +1,5 @@
 package org.stagemonitor.web.monitor.filter;
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +33,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.configuration.Configuration;
+import org.stagemonitor.core.util.CompletedFuture;
+import org.stagemonitor.core.util.ListenableFuture;
 import org.stagemonitor.requestmonitor.MonitoredRequest;
 import org.stagemonitor.requestmonitor.RequestMonitor;
 import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
@@ -75,7 +75,7 @@ public class HttpRequestMonitorFilterTest {
 				when(requestTrace.toJson()).thenReturn("");
 				when(requestTrace.getName()).thenReturn("testName");
 				when(requestInformation.getRequestTrace()).thenReturn(requestTrace);
-				return Futures.immediateFuture(requestInformation);
+				return new CompletedFuture<RequestMonitor.RequestInformation<?>>(requestInformation);
 			}
 		});
 


### PR DESCRIPTION
This PR removes the dependency on Guava for the ListenableFuture, by reimplementing it inside stagemonitor. This isn't ideal as it's some tricky logic to make sure works as expected regardless of what order stuff happens in (I'd be much happier using someone elses implementation).

This PR also removes the execute method, and renames the executeAsync method to replace it. The monitor method has also been changed to just wrap monitorAsync.