### PR TITLE
Include name, line number and expression of Freemarker templates in call tree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
 
 	dependencies {
 		testCompile 'junit:junit:4.12'
-		testCompile 'org.mockito:mockito-all:2.0.2-beta'
+		testCompile 'org.mockito:mockito-core:2.0.111-beta'
 		testCompile 'ch.qos.logback:logback-classic:1.1.7'
 		testCompile 'commons-io:commons-io:2.5'
 	}

--- a/stagemonitor-requestmonitor/build.gradle
+++ b/stagemonitor-requestmonitor/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile project(":stagemonitor-core")
 	optional "org.elasticsearch:elasticsearch:$esVersion"
 	optional 'javax.ejb:ejb-api:3.0'
+	optional 'org.freemarker:freemarker:2.3.23'
 
 	testCompile project(':stagemonitor-core').sourceSets.test.output
 	testCompile 'net.sf.ehcache:ehcache-core:2.6.6'

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformer.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformer.java
@@ -85,7 +85,7 @@ public class FreemarkerProfilingTransformer extends StagemonitorByteBuddyTransfo
 	 * Therefore, <code>getFoo</code> does not invoke the model and thus is not relevant for the call tree
 	 */
 	private static void removeCurrentNodeIfItHasNoChildren(CallStackElement currentFreemarkerCall) {
-		if (currentFreemarkerCall.getChildren().isEmpty()) {
+		if (currentFreemarkerCall != null && currentFreemarkerCall.getChildren().isEmpty()) {
 			currentFreemarkerCall.remove();
 		}
 	}

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformer.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformer.java
@@ -1,0 +1,92 @@
+package org.stagemonitor.requestmonitor.freemarker;
+
+import freemarker.core.Environment;
+import freemarker.core.Expression;
+
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import org.stagemonitor.core.instrument.StagemonitorByteBuddyTransformer;
+import org.stagemonitor.requestmonitor.profiler.CallStackElement;
+import org.stagemonitor.requestmonitor.profiler.Profiler;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+/**
+ * This class "profiles FTL files"
+ * <p/>
+ * This class actually adds expressions and methods which are evaluated by freemarker to the call tree. So that when a
+ * model class of our application is called, we know which FTL file originated the call.
+ * <p/>
+ * You may argue that this is not of particular interest because model objects are mostly POJOs and calling a getter
+ * is not interesting performance wise. This is true for POJOs but some applications may choose to not fully initialize
+ * the model objects but instead lazy-load the values on demand i.e. if they are actually needed for the template.
+ * <p/>
+ * Example:
+ *
+ * <pre>
+ * </code>
+ * test.ftl:1#templateModel.allTheThings
+ * `-- String org.example.TemplateModel.getAllTheThings()
+ *     `-- String org.example.ExampleDao.getAllTheThingsFromDB()
+ *         `-- SELECT * from THINGS
+ * </code>
+ * </pre>
+ */
+public class FreemarkerProfilingTransformer extends StagemonitorByteBuddyTransformer {
+
+	/**
+	 * Application code can be called by freemarker via the {@link freemarker.core.Dot} or the
+	 * {@link freemarker.core.MethodCall} classes.
+	 * <p/>
+	 * For example, when the expression ${templateModel.foo} is evaluated, {@link freemarker.core.Dot#_eval(Environment)}
+	 * evaluates <code>foo</code> by calling <code>TemplateModel#getFoo()</code>.
+	 * <p/>
+	 * The expression ${templateModel.getFoo()} will be evaluated a bit differently as {@link freemarker.core.Dot#_eval(Environment)}
+	 * only returns a reference to the method <code>TemplateModel#getFoo()</code> instead of calling it directly.
+	 * {@link freemarker.core.MethodCall#_eval(Environment)} then performs the actual call to <code>TemplateModel#getFoo()</code>.
+	 */
+	@Override
+	protected ElementMatcher.Junction<TypeDescription> getIncludeTypeMatcher() {
+		return named("freemarker.core.Dot").or(named("freemarker.core.MethodCall"));
+	}
+
+	@Override
+	protected ElementMatcher.Junction<MethodDescription.InDefinedShape> getExtraMethodElementMatcher() {
+		return named("_eval").and(takesArguments(Environment.class));
+	}
+
+	@Advice.OnMethodEnter(inline = false)
+	public static void onBeforeEvaluate(@Advice.Argument(0) Environment env, @Advice.This Expression dot) {
+		Profiler.start(env.getCurrentTemplate().getName() + ':' + dot.getBeginLine() + '#' + dot.toString());
+	}
+
+	@Advice.OnMethodExit(inline = false, onThrowable = Throwable.class)
+	public static void onAfterEvaluate() {
+		final CallStackElement currentFreemarkerCall = Profiler.getMethodCallParent();
+		Profiler.stop();
+		removeCurrentNodeIfItHasNoChildren(currentFreemarkerCall);
+	}
+
+	/**
+	 * <pre>
+	 * </code>
+	 * test.ftl:1#templateModel.getFoo() <- added by {@link freemarker.core.MethodCall#_eval(Environment)}
+	 * |-- test.ftl:1#templateModel.getFoo <- added by {@link freemarker.core.Dot#_eval(Environment)}
+	 * `-- String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()
+	 * </code>
+	 * </pre>
+	 *
+	 * We want to remove <code>templateModel.getFoo</code> as getFoo only returns the method reference, which is then
+	 * invoked by {@link freemarker.core.MethodCall#_eval(Environment)}.
+	 * Therefore, <code>getFoo</code> does not invoke the model and thus is not relevant for the call tree
+	 */
+	private static void removeCurrentNodeIfItHasNoChildren(CallStackElement currentFreemarkerCall) {
+		if (currentFreemarkerCall.getChildren().isEmpty()) {
+			currentFreemarkerCall.remove();
+		}
+	}
+}

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/profiler/CallStackElement.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/profiler/CallStackElement.java
@@ -1,5 +1,10 @@
 package org.stagemonitor.requestmonitor.profiler;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import org.stagemonitor.core.Stagemonitor;
+import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
+
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -7,10 +12,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.stagemonitor.core.Stagemonitor;
-import org.stagemonitor.requestmonitor.RequestMonitorPlugin;
 
 public class CallStackElement {
 
@@ -151,7 +152,7 @@ public class CallStackElement {
 	 * otherwise
 	 */
 	public String getShortSignature() {
-		if (signature.indexOf('(') == -1) {
+		if (signature.indexOf('(') == -1 || signature.indexOf(':') != -1) {
 			return null;
 		}
 		String[] split = signature.substring(0, signature.indexOf('(')).split("\\.");
@@ -172,6 +173,16 @@ public class CallStackElement {
 
 	private void removeLastChild() {
 		children.remove(children.size() - 1).recycle();
+	}
+
+	/**
+	 * Removes this node from the parent
+	 */
+	public void remove() {
+		if (parent != null) {
+			parent.getChildren().remove(this);
+			recycle();
+		}
 	}
 
 	public void executionStopped(long executionTime) {

--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/profiler/Profiler.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/profiler/Profiler.java
@@ -55,6 +55,10 @@ public final class Profiler {
 		methodCallParent.set(null);
 	}
 
+	/**
+	 * Adds the current
+	 * @return
+	 */
 	public static CallStackElement getMethodCallParent() {
 		return methodCallParent.get();
 	}

--- a/stagemonitor-requestmonitor/src/main/resources/META-INF/services/org.stagemonitor.core.instrument.StagemonitorByteBuddyTransformer
+++ b/stagemonitor-requestmonitor/src/main/resources/META-INF/services/org.stagemonitor.core.instrument.StagemonitorByteBuddyTransformer
@@ -3,3 +3,4 @@ org.stagemonitor.requestmonitor.profiler.elasticsearch.ElasticsearchSearchQueryT
 org.stagemonitor.requestmonitor.MethodLevelMonitorRequestsTransformer
 org.stagemonitor.requestmonitor.ClassLevelMonitorRequestsTransformer
 org.stagemonitor.requestmonitor.ejb.RemoteEjbMonitorTransformer
+org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTransformer

--- a/stagemonitor-requestmonitor/src/test/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTest.java
+++ b/stagemonitor-requestmonitor/src/test/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTest.java
@@ -1,0 +1,82 @@
+package org.stagemonitor.requestmonitor.freemarker;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+
+import org.junit.Test;
+import org.stagemonitor.requestmonitor.profiler.CallStackElement;
+import org.stagemonitor.requestmonitor.profiler.Profiler;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class FreemarkerProfilingTest {
+
+	@Test
+	public void testFreemarkerProfiling() throws Exception {
+		final CallStackElement callTree = Profiler.activateProfiling("testFreemarkerProfiling");
+		final String renderedTemplate = processTemplate("test.ftl", "${templateModel.foo}", new TemplateModel());
+		Profiler.stop();
+		Profiler.deactivateProfiling();
+		assertThat(renderedTemplate, is("foo"));
+		System.out.println(callTree);
+
+		assertThat(callTree.getChildren().size(), is(1));
+		final CallStackElement freemarkerNode = callTree.getChildren().get(0);
+		assertThat(freemarkerNode.getSignature(), is("test.ftl:1#templateModel.foo"));
+
+		assertThat(freemarkerNode.getChildren().size(), is(1));
+		final CallStackElement templateModelNode = freemarkerNode.getChildren().get(0);
+		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()"));
+	}
+
+	@Test
+	public void testFreemarkerProfilingMethodCall() throws Exception {
+		final CallStackElement callTree = Profiler.activateProfiling("testFreemarkerProfilingMethodCall");
+		final String renderedTemplate = processTemplate("test.ftl", "${templateModel.getFoo()}", new TemplateModel());
+		Profiler.stop();
+		Profiler.deactivateProfiling();
+		assertThat(renderedTemplate, is("foo"));
+		System.out.println(callTree);
+
+		assertThat(callTree.getChildren().size(), is(1));
+		final CallStackElement freemarkerNode = callTree.getChildren().get(0);
+		assertThat(freemarkerNode.getSignature(), is("test.ftl:1#templateModel.getFoo()"));
+
+		assertThat(freemarkerNode.getChildren().size(), is(1));
+		final CallStackElement templateModelNode = freemarkerNode.getChildren().get(0);
+		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()"));
+	}
+
+	@Test
+	public void testShortSignature() {
+		final String signature = "foobar.ftl:123#foo.getBar('123').baz";
+		// don't try to shorten ftl signatures
+		assertThat(CallStackElement.createRoot(signature).getShortSignature(), nullValue());
+	}
+
+	public static class TemplateModel {
+		public String getFoo() {
+			Profiler.start("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()");
+			try {
+				return "foo";
+			} finally {
+				Profiler.stop();
+			}
+		}
+	}
+
+	private String processTemplate(String templateName, String templateString, TemplateModel templateModel) throws IOException, TemplateException {
+		Template template = new Template(templateName, templateString, new Configuration(Configuration.VERSION_2_3_22));
+		StringWriter out = new StringWriter(templateString.length());
+		template.process(Collections.singletonMap("templateModel", templateModel), out);
+		return out.toString();
+	}
+
+}

--- a/stagemonitor-requestmonitor/src/test/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformerTest.java
+++ b/stagemonitor-requestmonitor/src/test/java/org/stagemonitor/requestmonitor/freemarker/FreemarkerProfilingTransformerTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-public class FreemarkerProfilingTest {
+public class FreemarkerProfilingTransformerTest {
 
 	@Test
 	public void testFreemarkerProfiling() throws Exception {
@@ -33,7 +33,7 @@ public class FreemarkerProfilingTest {
 
 		assertThat(freemarkerNode.getChildren().size(), is(1));
 		final CallStackElement templateModelNode = freemarkerNode.getChildren().get(0);
-		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()"));
+		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTransformerTest$TemplateModel.getFoo()"));
 	}
 
 	@Test
@@ -51,7 +51,13 @@ public class FreemarkerProfilingTest {
 
 		assertThat(freemarkerNode.getChildren().size(), is(1));
 		final CallStackElement templateModelNode = freemarkerNode.getChildren().get(0);
-		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()"));
+		assertThat(templateModelNode.getSignature(), is("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTransformerTest$TemplateModel.getFoo()"));
+	}
+
+	@Test
+	public void testFreemarkerWorksIfNotProfiling() throws Exception {
+		final String renderedTemplate = processTemplate("test.ftl", "${templateModel.getFoo()}", new TemplateModel());
+		assertThat(renderedTemplate, is("foo"));
 	}
 
 	@Test
@@ -63,7 +69,7 @@ public class FreemarkerProfilingTest {
 
 	public static class TemplateModel {
 		public String getFoo() {
-			Profiler.start("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTest$TemplateModel.getFoo()");
+			Profiler.start("String org.stagemonitor.requestmonitor.freemarker.FreemarkerProfilingTransformerTest$TemplateModel.getFoo()");
 			try {
 				return "foo";
 			} finally {

--- a/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/spring/SpringRequestMonitorTest.java
+++ b/stagemonitor-web/src/test/java/org/stagemonitor/web/monitor/spring/SpringRequestMonitorTest.java
@@ -1,34 +1,10 @@
 package org.stagemonitor.web.monitor.spring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.stagemonitor.core.metrics.metrics2.MetricName.name;
-import static org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy.METHOD_NAME_SPLIT_CAMEL_CASE;
-import static org.stagemonitor.requestmonitor.RequestMonitor.getRequest;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.regex.Pattern;
-
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -51,6 +27,28 @@ import org.stagemonitor.web.WebPlugin;
 import org.stagemonitor.web.monitor.HttpRequestTrace;
 import org.stagemonitor.web.monitor.MonitoredHttpRequest;
 import org.stagemonitor.web.monitor.filter.StatusExposingByteCountingServletResponse;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.stagemonitor.core.metrics.metrics2.MetricName.name;
+import static org.stagemonitor.requestmonitor.BusinessTransactionNamingStrategy.METHOD_NAME_SPLIT_CAMEL_CASE;
 
 public class SpringRequestMonitorTest {
 
@@ -108,15 +106,12 @@ public class SpringRequestMonitorTest {
 		when(handlerMethod.getMethod()).thenReturn(requestMappingMethod);
 		doReturn(TestController.class).when(handlerMethod).getBeanType();
 		when(handlerExecutionChain.getHandler()).thenReturn(handlerMethod);
-		when(requestMappingHandlerMapping.getHandler(Matchers.argThat(new BaseMatcher<HttpServletRequest>() {
+		when(requestMappingHandlerMapping.getHandler(ArgumentMatchers.argThat(new ArgumentMatcher<HttpServletRequest>() {
 			@Override
-			public boolean matches(Object item) {
-				return ((HttpServletRequest) item).getRequestURI().equals("/test/requestName");
+			public boolean matches(HttpServletRequest item) {
+				return item.getRequestURI().equals("/test/requestName");
 			}
 
-			@Override
-			public void describeTo(Description description) {
-			}
 		}))).thenReturn(handlerExecutionChain);
 		return requestMappingHandlerMapping;
 	}


### PR DESCRIPTION
Adds support to "profile" Freemarker template files. This feature answers the question "which FTL file (and line number) caused the call of a expensive method"?

This class actually adds expressions and methods which are evaluated by freemarker to the call tree. So that when a model class of our application is called, we know which FTL file originated the call.

You may argue that this is not of particular interest because model objects are mostly POJOs and calling a getter is not interesting performance wise. This is true for POJOs but some applications may choose to not fully initialize the model objects but instead lazy-load the values on demand i.e. if they are actually needed for the template.

Example:
```   
   test.ftl:1#templateModel.allTheThings
   `-- String org.example.TemplateModel.getAllTheThings()
       `-- String org.example.ExampleDao.getAllTheThingsFromDB()
           `-- SELECT * from THINGS
```

<img width="1302" alt="ftl-call-tree" src="https://cloud.githubusercontent.com/assets/2163464/18204235/efd3930c-711b-11e6-81e9-6d788736b261.png">
