### PR TITLE
Issue #218: Add a try / catch around String.ValueOf to prevent from t…

### DIFF
--- a/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
+++ b/stagemonitor-requestmonitor/src/main/java/org/stagemonitor/requestmonitor/MonitoredMethodRequest.java
@@ -36,7 +36,14 @@ public class MonitoredMethodRequest implements MonitoredRequest<RequestTrace> {
 		if (parameters != null && parameters.size() > 0) {
 			Map<String, String> params = new LinkedHashMap<String, String>();
 			for (Map.Entry<String, Object> entry : parameters.entrySet()) {
-				params.put(entry.getKey(), String.valueOf(entry.getValue()));
+				String valueAsString;
+				try {
+					valueAsString = String.valueOf(entry.getValue());
+				}
+				catch (Exception e) {
+					valueAsString = "[unavailable (" + e.getMessage() + ")]";
+				}
+				params.put(entry.getKey(), valueAsString);
 			}
 			requestTrace.setParameters(RequestMonitorPlugin.getSafeParameterMap(params, requestMonitorPlugin.getConfidentialParameters()));
 		}


### PR DESCRIPTION
…hrowing an unhandled exception when attempting to get the String representation of a parameter