### PR TITLE
Fix possible NPE in HttpClient.

### DIFF
--- a/cla/contributors/fantast.md
+++ b/cla/contributors/fantast.md
@@ -1,0 +1,27 @@
+2016-01-19
+
+I hereby agree to the terms of the Entity Contributors License
+Agreement, with MD5 checksum 3230b63601162567219de517a1be22b4.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+Paulenka Dzmitry, MINTDATA
+https://github.com/fantast
+
+---
+
+2016-01-19
+
+I hereby agree to the terms of the Individual Contributors License
+Agreement, with MD5 checksum 3455f69ed223b9e5712f8bb3abf38190.
+
+I furthermore declare that I am authorized and able to make this
+agreement and sign this declaration.
+
+Signed,
+
+Paulenka Dzmitry
+https://github.com/fantast

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/HttpClient.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/HttpClient.java
@@ -71,7 +71,8 @@ public class HttpClient {
 	}
 
 	public int send(final String method, final String url, final Map<String, String> headerFields, OutputStreamHandler outputStreamHandler) {
-		return send(method, url, headerFields, outputStreamHandler, new ErrorLoggingResponseHandler(url));
+		Integer result = send(method, url, headerFields, outputStreamHandler, new ErrorLoggingResponseHandler(url));
+		return result == null ? -1 : result;
 	}
 
 	public <T> T send(final String method, final String url, final Map<String, String> headerFields,

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/util/HttpClientTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/util/HttpClientTest.java
@@ -16,7 +16,7 @@ public class HttpClientTest {
 	}
 
 	@Test
-	public void testCopy() throws IOException {
+	public void testNoNullPointerExceptionOnSend() throws IOException {
 		try {
 			httpClient.send("POST", "incorrect-url", null, null);
 		} catch (NullPointerException t) {

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/util/HttpClientTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/util/HttpClientTest.java
@@ -1,0 +1,28 @@
+package org.stagemonitor.core.util;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpClientTest {
+
+	private HttpClient httpClient;
+
+	@Before
+	public void setup() {
+		httpClient = new HttpClient();
+	}
+
+	@Test
+	public void testCopy() throws IOException {
+		try {
+			httpClient.send("POST", "incorrect-url", null, null);
+		} catch (NullPointerException t) {
+			Assert.fail("Shouldn't throw NPE");
+		} catch (Exception ignore) {
+			//whatever
+		}
+	}
+}


### PR DESCRIPTION
In some rare, but possible scenario, we might catch a NullPointerException when unboxing occurs. This confuses the logs and reports unexpected errors to logs. This PR implement a simplest possible fix for this.