### PR TITLE
Add health checks to stagemonitor

### DIFF
--- a/stagemonitor-benchmark/build.gradle
+++ b/stagemonitor-benchmark/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	compile project(":stagemonitor-logging")
 	compile project(":stagemonitor-ehcache")
 	compile project(":stagemonitor-alerting")
+	compile project(":stagemonitor-tracing-elasticsearch")
+	compile project(":stagemonitor-os")
 	compile 'org.apache.commons:commons-io:1.3.2'
 	compile "org.slf4j:slf4j-simple:$slf4jVersion"
 	compile "org.elasticsearch:elasticsearch:$esVersion"

--- a/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationOptionsMarkdownExporter.java
+++ b/stagemonitor-benchmark/src/test/java/org/stagemonitor/ConfigurationOptionsMarkdownExporter.java
@@ -62,9 +62,9 @@ public class ConfigurationOptionsMarkdownExporter {
 		markdown.append("# Options by Tag\n");
 		markdown.append("\n");
 		for (Map.Entry<String, List<ConfigurationOption<?>>> entry : configurationOptionsByTags.entrySet()) {
-			markdown.append("* `").append(entry.getKey()).append("` \n");
+			markdown.append("## `").append(entry.getKey()).append("` \n");
 			for (ConfigurationOption<?> option : entry.getValue()) {
-				markdown.append("  * ").append(linkToHeadline(option.getLabel())).append('\n');
+				markdown.append(" * ").append(linkToHeadline(option.getLabel())).append('\n');
 			}}
 		markdown.append("\n");
 

--- a/stagemonitor-core/build.gradle
+++ b/stagemonitor-core/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compile "io.dropwizard.metrics:metrics-graphite:$metricsVersion"
 	compile "io.dropwizard.metrics:metrics-annotation:$metricsVersion"
 	compile "io.dropwizard.metrics:metrics-json:$metricsVersion"
+	compile "io.dropwizard.metrics:metrics-healthchecks:$metricsVersion"
 	compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 	compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
 	compile "net.bytebuddy:byte-buddy:$byteBuddyVersion"

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/StagemonitorPlugin.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/StagemonitorPlugin.java
@@ -1,5 +1,7 @@
 package org.stagemonitor.core;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
@@ -105,11 +107,13 @@ public abstract class StagemonitorPlugin extends ConfigurationOptionProvider imp
 		private final Metric2Registry metricRegistry;
 		private final ConfigurationRegistry configuration;
 		private final MeasurementSession measurementSession;
+		private final HealthCheckRegistry healthCheckRegistry;
 
-		public InitArguments(Metric2Registry metricRegistry, ConfigurationRegistry configuration, MeasurementSession measurementSession) {
+		public InitArguments(Metric2Registry metricRegistry, ConfigurationRegistry configuration, MeasurementSession measurementSession, HealthCheckRegistry healthCheckRegistry) {
 			this.metricRegistry = metricRegistry;
 			this.configuration = configuration;
 			this.measurementSession = measurementSession;
+			this.healthCheckRegistry = healthCheckRegistry;
 		}
 
 		public Metric2Registry getMetricRegistry() {
@@ -131,6 +135,10 @@ public abstract class StagemonitorPlugin extends ConfigurationOptionProvider imp
 
 		public MeasurementSession getMeasurementSession() {
 			return measurementSession;
+		}
+
+		public HealthCheckRegistry getHealthCheckRegistry() {
+			return healthCheckRegistry;
 		}
 	}
 

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/instrument/AgentAttacher.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/instrument/AgentAttacher.java
@@ -1,5 +1,8 @@
 package org.stagemonitor.core.instrument;
 
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -11,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.Stagemonitor;
+import org.stagemonitor.core.metrics.health.ImmediateResult;
 import org.stagemonitor.core.util.ClassUtils;
 import org.stagemonitor.util.IOUtils;
 
@@ -53,7 +57,8 @@ public class AgentAttacher {
 		}
 	};
 
-	private static CorePlugin corePlugin = Stagemonitor.getPlugin(CorePlugin.class);
+	private static final CorePlugin corePlugin = Stagemonitor.getPlugin(CorePlugin.class);
+	private static final HealthCheckRegistry healthCheckRegistry = Stagemonitor.getHealthCheckRegistry();
 	private static boolean runtimeAttached = false;
 	private static Set<String> hashCodesOfClassLoadersToIgnore = Collections.emptySet();
 	private static Instrumentation instrumentation;
@@ -96,6 +101,7 @@ public class AgentAttacher {
 	}
 
 	private static boolean initInstrumentation() {
+		healthCheckRegistry.register("instrumentation", ImmediateResult.of(HealthCheck.Result.unhealthy("Unknown error")));
 		try {
 			try {
 				instrumentation = ByteBuddyAgent.getInstrumentation();
@@ -105,6 +111,7 @@ public class AgentAttacher {
 								new EhCacheAttachmentProvider(),
 								ByteBuddyAgent.AttachmentProvider.DEFAULT));
 			}
+			healthCheckRegistry.register("instrumentation", ImmediateResult.of(HealthCheck.Result.healthy()));
 			ensureDispatcherIsAppendedToBootstrapClasspath(instrumentation);
 			if (!Dispatcher.getValues().containsKey(IGNORED_CLASSLOADERS_KEY)) {
 				Dispatcher.put(IGNORED_CLASSLOADERS_KEY, Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>()));
@@ -112,10 +119,12 @@ public class AgentAttacher {
 			hashCodesOfClassLoadersToIgnore = Dispatcher.get(IGNORED_CLASSLOADERS_KEY);
 			return true;
 		} catch (Exception e) {
-			logger.warn("Failed to perform runtime attachment of the stagemonitor agent. Make sure that you run your " +
+			final String msg = "Failed to perform runtime attachment of the stagemonitor agent. Make sure that you run your " +
 					"application with a JDK (not a JRE)." +
 					"To make stagemonitor work with a JRE, you have to add the following command line argument to the " +
-					"start of the JVM: -javaagent:/path/to/byte-buddy-agent-<version>.jar", e);
+					"start of the JVM: -javaagent:/path/to/byte-buddy-agent-<version>.jar";
+			healthCheckRegistry.register("instrumentation", ImmediateResult.of(HealthCheck.Result.unhealthy(msg)));
+			logger.warn(msg, e);
 			return false;
 		}
 	}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/health/ImmediateResult.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/health/ImmediateResult.java
@@ -1,0 +1,21 @@
+package org.stagemonitor.core.metrics.health;
+
+import com.codahale.metrics.health.HealthCheck;
+
+public class ImmediateResult extends HealthCheck {
+
+	private final Result result;
+
+	public static HealthCheck of(Result result) {
+		return new ImmediateResult(result);
+	}
+
+	private ImmediateResult(Result result) {
+		this.result = result;
+	}
+
+	@Override
+	protected Result check() throws Exception {
+		return result;
+	}
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/health/OverridableHealthCheckRegistry.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/health/OverridableHealthCheckRegistry.java
@@ -1,0 +1,14 @@
+package org.stagemonitor.core.metrics.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+public class OverridableHealthCheckRegistry extends HealthCheckRegistry {
+
+	@Override
+	public void register(String name, HealthCheck healthCheck) {
+		super.unregister(name);
+		super.register(name, healthCheck);
+	}
+
+}

--- a/stagemonitor-ehcache/src/main/java/org/stagemonitor/ehcache/EhCachePlugin.java
+++ b/stagemonitor-ehcache/src/main/java/org/stagemonitor/ehcache/EhCachePlugin.java
@@ -1,5 +1,8 @@
 package org.stagemonitor.ehcache;
 
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Ehcache;
@@ -11,6 +14,7 @@ import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.StagemonitorPlugin;
 import org.stagemonitor.core.elasticsearch.ElasticsearchClient;
 import org.stagemonitor.core.grafana.GrafanaClient;
+import org.stagemonitor.core.metrics.health.ImmediateResult;
 import org.stagemonitor.core.metrics.metrics2.Metric2Registry;
 import org.stagemonitor.tracing.SpanContextInformation;
 import org.stagemonitor.tracing.TracingPlugin;
@@ -43,6 +47,7 @@ public class EhCachePlugin extends StagemonitorPlugin {
 			.buildWithDefault(false);
 
 	private Metric2Registry metricRegistry;
+	private HealthCheckRegistry healthCheckRegistry;
 
 	/*
 	 * TODO monitor caches by instrumenting the constructor of net.sf.ehcache.Cache
@@ -52,12 +57,14 @@ public class EhCachePlugin extends StagemonitorPlugin {
 	@Override
 	public void initializePlugin(StagemonitorPlugin.InitArguments initArguments) {
 		this.metricRegistry = initArguments.getMetricRegistry();
+		healthCheckRegistry = initArguments.getHealthCheckRegistry();
 		TracingPlugin tracingPlugin = initArguments.getPlugin(TracingPlugin.class);
 		final CacheManager cacheManager = CacheManager.getCacheManager(ehCacheNameOption.getValue());
 		if (cacheManager == null) {
 			tryAgainWhenFirstRequestComesIn(tracingPlugin);
 		} else {
 			monitorCaches(cacheManager);
+			healthCheckRegistry.register("EhCache CacheManager", ImmediateResult.of(HealthCheck.Result.healthy()));
 		}
 
 		final CorePlugin corePlugin = initArguments.getPlugin(CorePlugin.class);
@@ -77,7 +84,15 @@ public class EhCachePlugin extends StagemonitorPlugin {
 		tracingPlugin.addSpanEventListenerFactory(new FirstOperationEventListener(tracingPlugin.getSpanWrappingTracer()) {
 			@Override
 			public void onFirstOperation(SpanWrapper spanWrapper) {
-				monitorCaches(CacheManager.getCacheManager(ehCacheNameOption.getValue()));
+				final CacheManager cacheManager = CacheManager.getCacheManager(ehCacheNameOption.getValue());
+				final HealthCheck check;
+				if (cacheManager != null) {
+					monitorCaches(cacheManager);
+					check = ImmediateResult.of(HealthCheck.Result.healthy("CacheManager found after first operation"));
+				} else {
+					check = ImmediateResult.of(HealthCheck.Result.unhealthy("CacheManager not found after first operation"));
+				}
+				healthCheckRegistry.register("EhCache CacheManager", check);
 			}
 
 			@Override

--- a/stagemonitor-os/src/test/java/org/stagemonitor/os/OsPluginTest.java
+++ b/stagemonitor-os/src/test/java/org/stagemonitor/os/OsPluginTest.java
@@ -1,6 +1,7 @@
 package org.stagemonitor.os;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.health.HealthCheckRegistry;
 
 import org.hyperic.sigar.FileSystem;
 import org.hyperic.sigar.Sigar;
@@ -48,7 +49,7 @@ public class OsPluginTest {
 		final CorePlugin corePlugin = mock(CorePlugin.class);
 		when(corePlugin.getElasticsearchClient()).thenReturn(mock(ElasticsearchClient.class));
 		when(configuration.getConfig(CorePlugin.class)).thenReturn(corePlugin);
-		osPlugin.initializePlugin(new StagemonitorPlugin.InitArguments(metricRegistry, configuration, mock(MeasurementSession.class)));
+		osPlugin.initializePlugin(new StagemonitorPlugin.InitArguments(metricRegistry, configuration, mock(MeasurementSession.class), mock(HealthCheckRegistry.class)));
 		this.sigar = osPlugin.getSigar();
 	}
 

--- a/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/ServletPlugin.java
+++ b/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/ServletPlugin.java
@@ -23,6 +23,7 @@ import org.stagemonitor.web.servlet.eum.ClientSpanServlet;
 import org.stagemonitor.web.servlet.eum.WeaselClientSpanExtension;
 import org.stagemonitor.web.servlet.filter.HttpRequestMonitorFilter;
 import org.stagemonitor.web.servlet.filter.StagemonitorSecurityFilter;
+import org.stagemonitor.web.servlet.health.HealthCheckServlet;
 import org.stagemonitor.web.servlet.session.SessionCounter;
 import org.stagemonitor.web.servlet.util.ServletContainerInitializerUtil;
 import org.stagemonitor.web.servlet.widget.SpanServlet;
@@ -472,5 +473,9 @@ public class ServletPlugin extends StagemonitorPlugin implements ServletContaine
 		} catch (IllegalArgumentException e) {
 			// embedded servlet containers like jetty don't necessarily support sessions
 		}
+
+		final ServletRegistration.Dynamic healthServlet = ctx.addServlet(HealthCheckServlet.class.getSimpleName(), new HealthCheckServlet(Stagemonitor.getHealthCheckRegistry()));
+		healthServlet.addMapping("/stagemonitor/status");
+		healthServlet.setAsyncSupported(true);
 	}
 }

--- a/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/health/HealthCheckServlet.java
+++ b/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/health/HealthCheckServlet.java
@@ -1,0 +1,26 @@
+package org.stagemonitor.web.servlet.health;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import org.stagemonitor.core.util.JsonUtils;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class HealthCheckServlet extends HttpServlet {
+
+	private final HealthCheckRegistry healthCheckRegistry;
+
+	public HealthCheckServlet(HealthCheckRegistry healthCheckRegistry) {
+		this.healthCheckRegistry = healthCheckRegistry;
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		JsonUtils.writeJsonToOutputStream(healthCheckRegistry.runHealthChecks(), resp.getOutputStream());
+	}
+}


### PR DESCRIPTION
After startup the status is logged on info level

stagemonitor-web-servlet adds an /stagemonitor/status
endpoint which lets you query the status at runtime

example log:

```
INFO  Stagemonitor - # stagemonitor status
INFO  Stagemonitor - OK   - AlertingPlugin (AlertingPlugin is initialized)
INFO  Stagemonitor - OK   - CorePlugin (CorePlugin is initialized)
INFO  Stagemonitor - OK   - EhCache CacheManager 
INFO  Stagemonitor - OK   - EhCachePlugin (EhCachePlugin is initialized)
INFO  Stagemonitor - OK   - ElasticsearchTracingPlugin (ElasticsearchTracingPlugin is initialized)
INFO  Stagemonitor - OK   - JdbcPlugin (JdbcPlugin is initialized)
INFO  Stagemonitor - OK   - JvmPlugin (JvmPlugin is initialized)
INFO  Stagemonitor - OK   - LoggingPlugin (LoggingPlugin is initialized)
INFO  Stagemonitor - OK   - OsPlugin (OsPlugin is initialized)
INFO  Stagemonitor - OK   - ServletPlugin (ServletPlugin is initialized)
INFO  Stagemonitor - OK   - TracingPlugin (TracingPlugin is initialized)
INFO  Stagemonitor - OK   - elasticsearch 
INFO  Stagemonitor - OK   - instrumentation 
INFO  Stagemonitor - OK   - instrumentation_datasource 
INFO  Stagemonitor - OK   - startup 
```