### PR TITLE
Fix configuration key documentation / alias key for confidential regex

### DIFF
--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/TracingPlugin.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/TracingPlugin.java
@@ -84,7 +84,7 @@ public class TracingPlugin extends StagemonitorPlugin {
 			.buildWithDefault(false);
 	private final ConfigurationOption<Collection<Pattern>> confidentialParameters = ConfigurationOption.regexListOption()
 			.key("stagemonitor.tracing.params.confidential.regex")
-			.aliasKeys("stagemonitor.requestmonitor.params.confidential.regex")
+			.aliasKeys("stagemonitor.requestmonitor.requestparams.confidential.regex", "stagemonitor.requestmonitor.params.confidential.regex")
 			.dynamic(true)
 			.label("Confidential parameters (regex)")
 			.description("A list of request parameter name patterns that should not be collected.\n" +

--- a/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/ServletPlugin.java
+++ b/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/ServletPlugin.java
@@ -72,7 +72,7 @@ public class ServletPlugin extends StagemonitorPlugin implements ServletContaine
 			.key("stagemonitor.requestmonitor.http.requestparams.confidential.regex")
 			.dynamic(true)
 			.label("Deprecated: Confidential request parameters (regex)")
-			.description("Deprecated, use stagemonitor.requestmonitor.requestparams.confidential.regex instead." +
+			.description("Deprecated, use stagemonitor.tracing.params.confidential.regex instead." +
 					"A list of request parameter name patterns that should not be collected.\n" +
 					"A request parameter is either a query string or a application/x-www-form-urlencoded request " +
 					"body (POST form content)")


### PR DESCRIPTION
fixes #289 

@felixbarny: I added the wrong configuration key to fix the configuration of users who are not aware of this issue.