### PR TITLE
Add logging of non-default configuration options

### DIFF
--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/ConfigurationOption.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/ConfigurationOption.java
@@ -491,6 +491,16 @@ public class ConfigurationOption<T> {
 		this.nameOfCurrentConfigurationSource = nameOfCurrentConfigurationSource;
 	}
 
+	/**
+	 * Returns true if the current value is equal to the default value
+	 *
+	 * @return true if the current value is equal to the default value
+	 */
+	public boolean isDefault() {
+		return (valueAsString != null && valueAsString.equals(defaultValueAsString)) ||
+				(valueAsString == null && defaultValueAsString == null);
+	}
+
 	public void addChangeListener(ChangeListener<T> changeListener) {
 		changeListeners.add(changeListener);
 	}


### PR DESCRIPTION
The log output looks like this:

	# stagemonitor configuration, listing non-default values:
	stagemonitor.web.paths.excluded: /resources, /webjars, /dandelion (source: stagemonitor.properties)
	stagemonitor.eum.enabled: true (source: Environment Variables)
	stagemonitor.reporting.interval.elasticsearch: 10 (source: stagemonitor.properties)
	stagemonitor.reporting.elasticsearch.url: http://localhost:9200 (source: stagemonitor.properties)
	stagemonitor.instrument.exclude: org.springframework.samples.petclinic.model (source: stagemonitor.properties)
	stagemonitor.instrument.include: org.springframework.samples.petclinic (source: stagemonitor.properties)
	stagemonitor.grafana.url: http://some-very-long-string-lorem-ipsum-dolor-sit-a... (source: stagemonitor.properties)
	stagemonitor.grafana.apiKey: XXXX (source: stagemonitor.properties)
	stagemonitor.alerts.frequency: 10 (source: stagemonitor.properties)

fixes #291