### PR TITLE
Remove warnings regarding kibana type mappings and "index already exists"-exception

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/CorePlugin.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/CorePlugin.java
@@ -451,12 +451,10 @@ public class CorePlugin extends StagemonitorPlugin {
 		// makes sure the .kibana index is present and has the right mapping.
 		// otherwise it leads to problems if stagemonitor sends the dashboards to the
 		// .kibana index before it has been properly created by kibana
-		// TODO: asynchronize this
-		elasticsearchClient.sendRequest("PUT", "/.kibana");
-		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/index-pattern", IOUtils.getResourceAsStream("kibana/kibana-index-index-pattern.json"));
-		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/search", IOUtils.getResourceAsStream("kibana/kibana-index-search.json"));
-		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/dashboard", IOUtils.getResourceAsStream("kibana/kibana-index-dashboard.json"));
-		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/visualization", IOUtils.getResourceAsStream("kibana/kibana-index-visualization.json"));
+		elasticsearchClient.createIndexAndSendMappingAsync(".kibana", "index-pattern", IOUtils.getResourceAsStream("kibana/kibana-index-index-pattern.json"));
+		elasticsearchClient.createIndexAndSendMappingAsync(".kibana", "search", IOUtils.getResourceAsStream("kibana/kibana-index-search.json"));
+		elasticsearchClient.createIndexAndSendMappingAsync(".kibana", "dashboard", IOUtils.getResourceAsStream("kibana/kibana-index-dashboard.json"));
+		elasticsearchClient.createIndexAndSendMappingAsync(".kibana", "visualization", IOUtils.getResourceAsStream("kibana/kibana-index-visualization.json"));
 	}
 
 	public static Future<?> sendConfigurationMappingAsync(ElasticsearchClient elasticsearchClient) {

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/CorePlugin.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/CorePlugin.java
@@ -451,6 +451,7 @@ public class CorePlugin extends StagemonitorPlugin {
 		// makes sure the .kibana index is present and has the right mapping.
 		// otherwise it leads to problems if stagemonitor sends the dashboards to the
 		// .kibana index before it has been properly created by kibana
+		// TODO: asynchronize this
 		elasticsearchClient.sendRequest("PUT", "/.kibana");
 		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/index-pattern", IOUtils.getResourceAsStream("kibana/kibana-index-index-pattern.json"));
 		elasticsearchClient.sendAsJson("PUT", "/.kibana/_mapping/search", IOUtils.getResourceAsStream("kibana/kibana-index-search.json"));

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/ElasticsearchReporter.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/ElasticsearchReporter.java
@@ -15,6 +15,7 @@ import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.elasticsearch.ElasticsearchClient;
 import org.stagemonitor.core.util.HttpClient;
 import org.stagemonitor.core.util.JsonUtils;
+import org.stagemonitor.core.util.http.NoopResponseHandler;
 import org.stagemonitor.util.StringUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -74,7 +75,7 @@ public class ElasticsearchReporter extends ScheduledMetrics2Reporter {
 			}
 
 			httpClient.send("POST", corePlugin.getElasticsearchUrl() + "/_bulk", CONTENT_TYPE_JSON,
-					metricsOutputStreamHandler, HttpClient.NoopResponseHandler.INSTANCE);
+					metricsOutputStreamHandler, NoopResponseHandler.INSTANCE);
 		} else {
 			try {
 				final ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/ErrorLoggingResponseHandler.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/ErrorLoggingResponseHandler.java
@@ -1,0 +1,33 @@
+package org.stagemonitor.core.util.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.stagemonitor.core.util.HttpClient;
+import org.stagemonitor.util.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ErrorLoggingResponseHandler implements HttpClient.ResponseHandler<Integer> {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final String url;
+
+	public ErrorLoggingResponseHandler(String url) {
+		this.url = url;
+	}
+
+	@Override
+	public Integer handleResponse(InputStream is, Integer statusCode, IOException e) throws IOException {
+		if (statusCode == null) {
+			return -1;
+		}
+		if (statusCode >= 400) {
+			logger.warn(url + ": " + statusCode + " " + IOUtils.toString(is));
+		} else {
+			IOUtils.consumeAndClose(is);
+		}
+		return statusCode;
+	}
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequest.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequest.java
@@ -1,0 +1,13 @@
+package org.stagemonitor.core.util.http;
+
+import org.stagemonitor.core.util.HttpClient;
+
+import java.util.Map;
+
+public interface HttpRequest<T> {
+	String getMethod();
+	String getUrl();
+	Map<String, String> getHeaders();
+	HttpClient.OutputStreamHandler getOutputStreamHandler();
+	HttpClient.ResponseHandler<T> getResponseHandler();
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequestBuilder.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequestBuilder.java
@@ -1,0 +1,90 @@
+package org.stagemonitor.core.util.http;
+
+import org.stagemonitor.core.util.HttpClient;
+import org.stagemonitor.util.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class HttpRequestBuilder<T> {
+
+	private String url;
+	private String method;
+	private Map<String, String> headers;
+	private HttpClient.OutputStreamHandler outputStreamHandler;
+	private HttpClient.ResponseHandler<T> responseHandler;
+	private Set<Integer> errorStatusCodesIgnored;
+
+	public HttpRequestBuilder() {
+		headers = new HashMap<String, String>();
+		responseHandler = NoopResponseHandler.INSTANCE;
+		outputStreamHandler = NoopOutputStreamHandler.INSTANCE;
+		errorStatusCodesIgnored = new HashSet<Integer>();
+	}
+
+	public HttpRequestBuilder url(String url) {
+		this.url = url;
+		return this;
+	}
+
+	public HttpRequestBuilder method(String method) {
+		this.method = method;
+		return this;
+	}
+
+	public HttpRequestBuilder headers(Map<String, String> headers) {
+		this.headers = headers;
+		return this;
+	}
+
+	public HttpRequestBuilder outputStreamHandler(HttpClient.OutputStreamHandler outputStreamHandler) {
+		this.outputStreamHandler = outputStreamHandler;
+		return this;
+	}
+
+	public HttpRequestBuilder responseHandler(HttpClient.ResponseHandler<T> responseHandler) {
+		this.responseHandler = responseHandler;
+		return this;
+	}
+
+	public HttpRequestBuilder skipErrorLoggingFor(Integer... errorStatusCodesIgnored) {
+		this.errorStatusCodesIgnored = new HashSet<Integer>(Arrays.asList(errorStatusCodesIgnored));
+		return this;
+	}
+
+	public HttpRequestBuilder<T> body(final InputStream inputStream) {
+		this.outputStreamHandler = new HttpClient.OutputStreamHandler() {
+			@Override
+			public void withHttpURLConnection(OutputStream outputStream) throws IOException {
+				IOUtils.copy(inputStream, outputStream);
+				inputStream.close();
+				outputStream.close();
+			}
+		};
+		return this;
+	}
+
+	public HttpRequest<T> build() {
+		return new HttpRequestImpl<T>(url, method, headers, outputStreamHandler, new HttpClient.ResponseHandler<T>() {
+			@Override
+			public T handleResponse(InputStream is, Integer statusCode, IOException e) throws IOException {
+				if (errorStatusCodesIgnored.contains(statusCode)) {
+					IOUtils.consumeAndClose(is);
+					return null;
+				} else if (statusCode >= 400) {
+					new ErrorLoggingResponseHandler(HttpClient.removeUserInfo(url)).handleResponse(is, statusCode, e);
+					return null;
+				} else {
+					return responseHandler.handleResponse(is, statusCode, e);
+				}
+			}
+		});
+	}
+
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequestImpl.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/HttpRequestImpl.java
@@ -1,0 +1,47 @@
+package org.stagemonitor.core.util.http;
+
+import org.stagemonitor.core.util.HttpClient;
+
+import java.util.Map;
+
+public class HttpRequestImpl<T> implements HttpRequest<T> {
+
+	private final String url;
+	private final String method;
+	private final Map<String, String> headers;
+	private final HttpClient.OutputStreamHandler outputStreamHandler;
+	private final HttpClient.ResponseHandler<T> responseHandler;
+
+	public HttpRequestImpl(String url, String method, Map<String, String> headers,
+						   HttpClient.OutputStreamHandler outputStreamHandler, HttpClient.ResponseHandler<T> responseHandler) {
+		this.url = url;
+		this.method = method;
+		this.headers = headers;
+		this.outputStreamHandler = outputStreamHandler;
+		this.responseHandler = responseHandler;
+	}
+
+	@Override
+	public String getUrl() {
+		return url;
+	}
+
+	@Override
+	public String getMethod() {
+		return method;
+	}
+
+	@Override
+	public Map<String, String> getHeaders() {
+		return headers;
+	}
+
+	public HttpClient.OutputStreamHandler getOutputStreamHandler() {
+		return outputStreamHandler;
+	}
+
+	@Override
+	public HttpClient.ResponseHandler<T> getResponseHandler() {
+		return responseHandler;
+	}
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/NoopOutputStreamHandler.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/NoopOutputStreamHandler.java
@@ -1,0 +1,19 @@
+package org.stagemonitor.core.util.http;
+
+import org.stagemonitor.core.util.HttpClient.OutputStreamHandler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class NoopOutputStreamHandler implements OutputStreamHandler {
+
+	public static final NoopOutputStreamHandler INSTANCE = new NoopOutputStreamHandler();
+
+	NoopOutputStreamHandler() {
+	}
+
+	@Override
+	public void withHttpURLConnection(OutputStream os) throws IOException {
+		os.close();
+	}
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/NoopResponseHandler.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/util/http/NoopResponseHandler.java
@@ -1,0 +1,23 @@
+package org.stagemonitor.core.util.http;
+
+import org.stagemonitor.core.util.HttpClient;
+import org.stagemonitor.util.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class NoopResponseHandler<T> implements HttpClient.ResponseHandler<T> {
+
+	public static final NoopResponseHandler INSTANCE = new NoopResponseHandler();
+
+	NoopResponseHandler() {
+	}
+
+	@Override
+	public T handleResponse(InputStream is, Integer statusCode, IOException e) throws IOException {
+		// we have to read the whole response, otherwise bad things happen
+		IOUtils.consumeAndClose(is);
+		return null;
+	}
+
+}

--- a/stagemonitor-core/src/main/resources/kibana/kibana-index-dashboard.json
+++ b/stagemonitor-core/src/main/resources/kibana/kibana-index-dashboard.json
@@ -22,7 +22,7 @@
 		"refreshInterval": {
 			"properties": {
 				"display": {
-					"type": "text"
+					"type": "keyword"
 				},
 				"pause": {
 					"type": "boolean"
@@ -36,13 +36,13 @@
 			}
 		},
 		"timeFrom": {
-			"type": "text"
+			"type": "keyword"
 		},
 		"timeRestore": {
 			"type": "boolean"
 		},
 		"timeTo": {
-			"type": "text"
+			"type": "keyword"
 		},
 		"title": {
 			"type": "text"

--- a/stagemonitor-core/src/main/resources/kibana/kibana-index-index-pattern.json
+++ b/stagemonitor-core/src/main/resources/kibana/kibana-index-index-pattern.json
@@ -1,40 +1,25 @@
 {
 	"properties": {
 		"fieldFormatMap": {
-			"type": "text",
-			"fields": {
-				"keyword": {
-					"type": "keyword",
-					"ignore_above": 256
-				}
-			}
+			"type": "text"
 		},
 		"fields": {
-			"type": "text",
-			"fields": {
-				"keyword": {
-					"type": "keyword",
-					"ignore_above": 256
-				}
-			}
+			"type": "text"
+		},
+		"intervalName": {
+			"type": "keyword"
+		},
+		"notExpandable": {
+			"type": "boolean"
+		},
+		"sourceFilters": {
+			"type": "text"
 		},
 		"timeFieldName": {
-			"type": "text",
-			"fields": {
-				"keyword": {
-					"type": "keyword",
-					"ignore_above": 256
-				}
-			}
+			"type": "keyword"
 		},
 		"title": {
-			"type": "text",
-			"fields": {
-				"keyword": {
-					"type": "keyword",
-					"ignore_above": 256
-				}
-			}
+			"type": "text"
 		}
 	}
 }

--- a/stagemonitor-core/src/main/resources/kibana/kibana-index-search.json
+++ b/stagemonitor-core/src/main/resources/kibana/kibana-index-search.json
@@ -1,7 +1,7 @@
 {
 	"properties": {
 		"columns": {
-			"type": "text"
+			"type": "keyword"
 		},
 		"description": {
 			"type": "text"
@@ -17,7 +17,7 @@
 			}
 		},
 		"sort": {
-			"type": "text"
+			"type": "keyword"
 		},
 		"title": {
 			"type": "text"

--- a/stagemonitor-core/src/main/resources/kibana/kibana-index-visualization.json
+++ b/stagemonitor-core/src/main/resources/kibana/kibana-index-visualization.json
@@ -11,7 +11,7 @@
 			}
 		},
 		"savedSearchId": {
-			"type": "text"
+			"type": "keyword"
 		},
 		"title": {
 			"type": "text"


### PR DESCRIPTION
This PR updates the kibana type mappings to 5.6, errors like the following should cease to exist till kibana changes the mapping the next time:

```
WARN  HttpClient$ErrorLoggingResponseHandler - http://XXXX:XXXX@localhost:9200/.kibana/_mapping/index-pattern: 400 {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"mapper [timeFieldName] of different type, current_type [keyword], merged_type [text]"}],"type":"illegal_argument_exception","reason":"mapper [timeFieldName] of different type, current_type [keyword], merged_type [text]"},"status":400}
```

The type mapping update is now asynchronous. It tries to create the kibana index first, if it already exists it swallows the "Index already exists"-Error.

`HttpRequestBuilder` is a draft for a simple HTTP-API. I would suggest to hide details regarding HTTP in classes like `ElasticsearchClient`, which build `HttpRequest`-Objects for the specific business operation on demand. The API of `HttpRequestBuilder` is definitely not final and I started with the use-cases for this PR (reworking the import of the kibana mappings).