### PR TITLE
Sample once per trace

### DIFF
--- a/stagemonitor-jdbc/build.gradle
+++ b/stagemonitor-jdbc/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile project(":stagemonitor-tracing")
 	compile 'p6spy:p6spy:3.0.0'
 
+	testCompile project(':stagemonitor-tracing').sourceSets.test.output
 	testCompile 'org.apache.tomcat:tomcat-jdbc:8.5.0'
 	testCompile 'org.hsqldb:hsqldb:2.3.3'
 	testCompile 'com.mchange:c3p0:0.9.5.2'

--- a/stagemonitor-jdbc/src/test/java/org/stagemonitor/jdbc/ConnectionMonitoringTransformerTest.java
+++ b/stagemonitor-jdbc/src/test/java/org/stagemonitor/jdbc/ConnectionMonitoringTransformerTest.java
@@ -9,6 +9,7 @@ import com.p6spy.engine.spy.P6DataSource;
 import com.zaxxer.hikari.HikariDataSource;
 
 import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -20,6 +21,7 @@ import org.stagemonitor.core.MeasurementSession;
 import org.stagemonitor.core.Stagemonitor;
 import org.stagemonitor.core.metrics.metrics2.Metric2Registry;
 import org.stagemonitor.core.metrics.metrics2.MetricName;
+import org.stagemonitor.tracing.GlobalTracerTestHelper;
 import org.stagemonitor.tracing.MonitoredMethodRequest;
 import org.stagemonitor.tracing.RequestMonitor;
 import org.stagemonitor.tracing.SpanContextInformation;
@@ -97,6 +99,7 @@ public class ConnectionMonitoringTransformerTest {
 
 	@BeforeClass
 	public static void attachProfiler() throws Exception {
+		GlobalTracerTestHelper.resetGlobalTracer();
 		Stagemonitor.reset(new MeasurementSession("ConnectionMonitoringTransformerTest", "test", "test"));
 	}
 
@@ -112,6 +115,11 @@ public class ConnectionMonitoringTransformerTest {
 		requestMonitor = Stagemonitor.getPlugin(TracingPlugin.class).getRequestMonitor();
 		configuration = Stagemonitor.getConfiguration();
 		testDao = new TestDao(dataSource);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GlobalTracerTestHelper.resetGlobalTracer();
 	}
 
 	@AfterClass

--- a/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/AbstractElasticsearchSpanReporterTest.java
+++ b/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/AbstractElasticsearchSpanReporterTest.java
@@ -64,7 +64,6 @@ public class AbstractElasticsearchSpanReporterTest {
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinute()).thenReturn(1000000d);
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
-		when(tracingPlugin.getRateLimitSpansPerMinutePerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getProfilerRateLimitPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercentOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerTypeOption()).thenReturn(mock(ConfigurationOption.class));

--- a/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/impl/JaegerTracerFactoryTest.java
+++ b/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/impl/JaegerTracerFactoryTest.java
@@ -1,0 +1,30 @@
+package org.stagemonitor.tracing.elasticsearch.impl;
+
+import org.junit.Test;
+import org.stagemonitor.core.MeasurementSession;
+import org.stagemonitor.core.StagemonitorPlugin;
+import org.stagemonitor.tracing.utils.SpanUtils;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JaegerTracerFactoryTest {
+
+	@Test
+	public void testIsRoot() throws Exception {
+		final StagemonitorPlugin.InitArguments initArguments = mock(StagemonitorPlugin.InitArguments.class);
+		when(initArguments.getMeasurementSession()).thenReturn(
+				new MeasurementSession("JaegerTracerFactoryTest", "test", "test"));
+		final Tracer tracer = new JaegerTracerFactory().getTracer(initArguments);
+		try (final Span rootSpan = tracer.buildSpan("foo").start()) {
+			try (final Span childSpan = tracer.buildSpan("bar").asChildOf(rootSpan).start()) {
+				assertThat(SpanUtils.isRoot(tracer, rootSpan)).isTrue();
+				assertThat(SpanUtils.isRoot(tracer, childSpan)).isFalse();
+			}
+		}
+	}
+}

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/sampling/ProbabilisticSamplingPreExecutionInterceptor.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/sampling/ProbabilisticSamplingPreExecutionInterceptor.java
@@ -4,6 +4,8 @@ import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 import org.stagemonitor.tracing.SpanContextInformation;
 import org.stagemonitor.tracing.TracingPlugin;
+import org.stagemonitor.tracing.utils.SpanUtils;
+import org.stagemonitor.tracing.wrapper.SpanWrapper;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -49,12 +51,18 @@ public class ProbabilisticSamplingPreExecutionInterceptor extends PreExecutionSp
 		final String operationType = spanContext.getOperationType();
 		if (sampleDecisionsByType.containsKey(operationType)) {
 			sampleDecisions = sampleDecisionsByType.get(operationType);
-		} else {
+		} else if (isRoot(context.getSpanContext().getSpanWrapper())) {
 			sampleDecisions = defaultSampleDecisions;
+		} else {
+			return;
 		}
 		if (sampleDecisions != null && !isSampled(sampleDecisions, spanCounter)) {
 			context.shouldNotReport(getClass());
 		}
+	}
+
+	protected boolean isRoot(SpanWrapper span) {
+		return SpanUtils.isRoot(span);
 	}
 
 	private boolean isSampled(BitSet sampleDecisions, AtomicInteger spanCounter) {

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/utils/RateLimiter.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/utils/RateLimiter.java
@@ -34,7 +34,7 @@ public class RateLimiter {
 		this.creditsPerNanosecond = creditsPerSecond / 1.0e9;
 	}
 
-	public boolean checkCredit(double itemCost) {
+	public synchronized boolean checkCredit(double itemCost) {
 		long currentTime = System.nanoTime();
 		double elapsedTime = currentTime - lastTick;
 		lastTick = currentTime;

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/utils/SpanUtils.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/utils/SpanUtils.java
@@ -1,6 +1,7 @@
 package org.stagemonitor.tracing.utils;
 
 import org.stagemonitor.core.util.InetAddresses;
+import org.stagemonitor.tracing.B3HeaderFormat;
 import org.stagemonitor.tracing.wrapper.SpanWrapper;
 
 import java.io.PrintWriter;
@@ -12,7 +13,9 @@ import java.util.Collection;
 import java.util.Map;
 
 import io.opentracing.Span;
+import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 
 public class SpanUtils {
 
@@ -88,5 +91,14 @@ public class SpanUtils {
 
 	public static boolean isServerRequest(SpanWrapper spanWrapper) {
 		return Tags.SPAN_KIND_SERVER.equals(spanWrapper.getStringTag(Tags.SPAN_KIND.getKey()));
+	}
+
+	// TODO replace with Span#isRoot when https://github.com/opentracing/specification/issues/91 is resolved
+	public static boolean isRoot(Span span) {
+		return isRoot(GlobalTracer.get(), span);
+	}
+
+	public static boolean isRoot(Tracer tracer, Span span) {
+		return B3HeaderFormat.getB3Identifiers(tracer, span).getParentSpanId() == null;
 	}
 }

--- a/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/AbstractRequestMonitorTest.java
+++ b/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/AbstractRequestMonitorTest.java
@@ -71,7 +71,6 @@ public abstract class AbstractRequestMonitorTest {
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercent()).thenReturn(1.0);
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerType()).thenReturn(Collections.emptyMap());
-		when(tracingPlugin.getRateLimitSpansPerMinutePerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		doReturn(mock(ConfigurationOption.class)).when(tracingPlugin).getProfilerRateLimitPerMinuteOption();
 		doReturn(mock(Timer.class)).when(registry).timer(any(MetricName.class));
 		doReturn(mock(Meter.class)).when(registry).meter(any(MetricName.class));

--- a/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/GlobalTracerTestHelper.java
+++ b/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/GlobalTracerTestHelper.java
@@ -1,0 +1,19 @@
+package org.stagemonitor.tracing;
+
+import java.lang.reflect.Field;
+
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.util.GlobalTracer;
+
+public class GlobalTracerTestHelper {
+
+	public static void resetGlobalTracer() {
+		try {
+			final Field tracerField = GlobalTracer.class.getDeclaredField("tracer");
+			tracerField.setAccessible(true);
+			tracerField.set(null, NoopTracerFactory.create());
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/MonitoredMethodExecutionTest.java
+++ b/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/MonitoredMethodExecutionTest.java
@@ -39,7 +39,6 @@ public class MonitoredMethodExecutionTest {
 		CorePlugin corePlugin = mock(CorePlugin.class);
 		TracingPlugin tracingPlugin = mock(TracingPlugin.class);
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
-		when(tracingPlugin.getRateLimitSpansPerMinutePerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercentOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercent()).thenReturn(1.0);

--- a/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/TracedTransformerTest.java
+++ b/stagemonitor-tracing/src/test/java/org/stagemonitor/tracing/TracedTransformerTest.java
@@ -54,6 +54,7 @@ public class TracedTransformerTest {
 
 	@After
 	public void tearDown() throws Exception {
+		GlobalTracerTestHelper.resetGlobalTracer();
 		assertThat(TracingUtils.getTraceContext().isEmpty()).isTrue();
 	}
 

--- a/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/jaxrs/JaxRsRequestNameDeterminerTransformerTest.java
+++ b/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/jaxrs/JaxRsRequestNameDeterminerTransformerTest.java
@@ -69,7 +69,6 @@ public class JaxRsRequestNameDeterminerTransformerTest {
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinute()).thenReturn(1000000d);
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
-		when(tracingPlugin.getRateLimitSpansPerMinutePerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercentOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercent()).thenReturn(1.0);

--- a/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/spring/SpringRequestMonitorTest.java
+++ b/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/spring/SpringRequestMonitorTest.java
@@ -102,7 +102,6 @@ public class SpringRequestMonitorTest {
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinute()).thenReturn(1_000_000.0);
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinuteOption()).thenReturn(mock(ConfigurationOption.class));
-		when(tracingPlugin.getRateLimitSpansPerMinutePerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercentOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getRateLimitSpansPerMinutePercentPerTypeOption()).thenReturn(mock(ConfigurationOption.class));
 		when(tracingPlugin.getDefaultRateLimitSpansPercent()).thenReturn(1.0);


### PR DESCRIPTION
Previously, the sampling decision has been made for each span individually,
but that lead to incomplete and fragmented traces.
Now the sampling decision is only made for root spans so that a trace as a
whole is either completely sampled or not sampled.

One exception is the sampling per individual operation type.
For example you can say I want only 10% of my jdbc spans to be sampled.
This decision is made regardless of the global (per-trace) decision.

An alternative would have been to have a layered sampling like sample
10% of all traces and of those, only sample 50% of the jdbc spans.
This quickly gets quite difficult, especially when you want to see how
many "insertNewUser" statements have been executed within the last hour.
In the example above, if the dashboard says 5 statements within the last
hour, its actually 5/0.5/0.1=100.

The advantage of the current implementation is that you can more easily
tell the effective sampling rate.
If you say jdbc: 0.1 its 10% no matter of the general sampling rate

See also https://github.com/opentracing/specification/issues/91