### PR TITLE
Strip sensitive information from urls

### DIFF
--- a/stagemonitor-alerting/src/test/java/org/stagemonitor/alerting/alerter/ElasticsearchAlerterTest.java
+++ b/stagemonitor-alerting/src/test/java/org/stagemonitor/alerting/alerter/ElasticsearchAlerterTest.java
@@ -19,7 +19,7 @@ public class ElasticsearchAlerterTest extends AbstractElasticsearchTest {
 
 	@Before
 	public void setUp() throws Exception {
-		abstractAlerterTest.configurationSource.add("stagemonitor.reporting.elasticsearch.url", elasticsearchUrl);
+		abstractAlerterTest.configurationSource.add("stagemonitor.reporting.elasticsearch.url", elasticsearchUrl.toString());
 		abstractAlerterTest.configuration.reloadDynamicConfigurationOptions();
 		elasticsearchAlerter = new ElasticsearchAlerter(abstractAlerterTest.configuration, new HttpClient());
 		this.alertSender = abstractAlerterTest.createAlertSender(elasticsearchAlerter);

--- a/stagemonitor-alerting/src/test/java/org/stagemonitor/alerting/alerter/HttpAlerterTest.java
+++ b/stagemonitor-alerting/src/test/java/org/stagemonitor/alerting/alerter/HttpAlerterTest.java
@@ -18,7 +18,7 @@ public class HttpAlerterTest extends AbstractElasticsearchTest {
 
 	@Before
 	public void setUp() throws Exception {
-		abstractAlerterTest.configurationSource.add("stagemonitor.reporting.elasticsearch.url", elasticsearchUrl);
+		abstractAlerterTest.configurationSource.add("stagemonitor.reporting.elasticsearch.url", elasticsearchUrl.toString());
 		abstractAlerterTest.configuration.reloadDynamicConfigurationOptions();
 		httpAlerter = new HttpAlerter();
 		this.alertSender = abstractAlerterTest.createAlertSender(httpAlerter);

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/ConfigurationOption.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/ConfigurationOption.java
@@ -11,16 +11,19 @@ import org.stagemonitor.configuration.converter.DoubleValueConverter;
 import org.stagemonitor.configuration.converter.EnumValueConverter;
 import org.stagemonitor.configuration.converter.IntegerValueConverter;
 import org.stagemonitor.configuration.converter.JsonValueConverter;
+import org.stagemonitor.configuration.converter.ListValueConverter;
 import org.stagemonitor.configuration.converter.LongValueConverter;
 import org.stagemonitor.configuration.converter.MapValueConverter;
 import org.stagemonitor.configuration.converter.OptionalValueConverter;
 import org.stagemonitor.configuration.converter.RegexValueConverter;
 import org.stagemonitor.configuration.converter.SetValueConverter;
 import org.stagemonitor.configuration.converter.StringValueConverter;
+import org.stagemonitor.configuration.converter.UrlValueConverter;
 import org.stagemonitor.configuration.converter.ValueConverter;
 import org.stagemonitor.configuration.source.ConfigurationSource;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -215,6 +218,25 @@ public class ConfigurationOption<T> {
 		return optionBuilder;
 	}
 
+	/**
+	 * Constructs a {@link ConfigurationOptionBuilder} whose value is of type {@link String}
+	 *
+	 * @return a {@link ConfigurationOptionBuilder} whose value is of type {@link String}
+	 */
+	public static ConfigurationOptionBuilder<URL> urlOption() {
+		return new ConfigurationOptionBuilder<URL>(UrlValueConverter.INSTANCE, URL.class);
+	}
+
+	/**
+	 * Constructs a {@link ConfigurationOptionBuilder} whose value is of type {@link String}
+	 *
+	 * @return a {@link ConfigurationOptionBuilder} whose value is of type {@link String}
+	 */
+	public static ConfigurationOptionBuilder<List<URL>> urlsOption() {
+		return new ConfigurationOptionBuilder<List<URL>>(new ListValueConverter<URL>(UrlValueConverter.INSTANCE), List.class)
+				.defaultValue(Collections.<URL>emptyList());
+	}
+
 	private ConfigurationOption(boolean dynamic, boolean sensitive, String key, String label, String description,
 								T defaultValue, String configurationCategory, final ValueConverter<T> valueConverter,
 								Class<? super T> valueType, List<String> tags, boolean required,
@@ -310,6 +332,10 @@ public class ConfigurationOption<T> {
 	 */
 	public String getValueAsString() {
 		return valueAsString;
+	}
+
+	public String getValueAsSafeString() {
+		return valueConverter.toSafeString(value);
 	}
 
 	/**

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/AbstractCollectionValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/AbstractCollectionValueConverter.java
@@ -1,0 +1,43 @@
+package org.stagemonitor.configuration.converter;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public abstract class AbstractCollectionValueConverter<C extends Collection<V>, V> extends AbstractValueConverter<C> {
+
+	protected final ValueConverter<V> valueConverter;
+
+	public AbstractCollectionValueConverter(ValueConverter<V> valueConverter) {
+		this.valueConverter = valueConverter;
+	}
+
+	@Override
+	public String toString(C value) {
+		return getString(value, false);
+	}
+
+	@Override
+	public String toSafeString(C value) {
+		return getString(value, true);
+	}
+
+	private String getString(C value, boolean safeString) {
+		Iterator<V> it = value.iterator();
+		if (!it.hasNext()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		for (; ; ) {
+			V e = it.next();
+			if (safeString) {
+				sb.append(valueConverter.toSafeString(e));
+			} else {
+				sb.append(valueConverter.toString(e));
+			}
+			if (!it.hasNext()) {
+				return sb.toString();
+			}
+			sb.append(',');
+		}
+	}
+}

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/AbstractValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/AbstractValueConverter.java
@@ -1,0 +1,10 @@
+package org.stagemonitor.configuration.converter;
+
+public abstract class AbstractValueConverter<T> implements ValueConverter<T> {
+
+	@Override
+	public String toSafeString(T value) {
+		return toString(value);
+	}
+
+}

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/BooleanValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/BooleanValueConverter.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.configuration.converter;
 
-public class BooleanValueConverter implements ValueConverter<Boolean> {
+public class BooleanValueConverter extends AbstractValueConverter<Boolean> {
 
 	public static final BooleanValueConverter INSTANCE = new BooleanValueConverter();
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ClassInstanceValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ClassInstanceValueConverter.java
@@ -7,7 +7,7 @@ package org.stagemonitor.configuration.converter;
  *
  * @param <T> the type of the class
  */
-public class ClassInstanceValueConverter<T> implements ValueConverter<T> {
+public class ClassInstanceValueConverter<T> extends AbstractValueConverter<T> {
 
 	private final Class<T> clazz;
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/DoubleValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/DoubleValueConverter.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.configuration.converter;
 
-public class DoubleValueConverter implements ValueConverter<Double> {
+public class DoubleValueConverter extends AbstractValueConverter<Double> {
 
 	public static final ValueConverter<Double> INSTANCE = new DoubleValueConverter();
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/EnumValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/EnumValueConverter.java
@@ -3,7 +3,7 @@ package org.stagemonitor.configuration.converter;
 /**
  * Converts an {@link Enum} to a {@link String} and back
  */
-public class EnumValueConverter<T extends Enum<T>> implements ValueConverter<T> {
+public class EnumValueConverter<T extends Enum<T>> extends AbstractValueConverter<T> {
 
 	private final Class<T> enumClass;
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/IntegerValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/IntegerValueConverter.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.configuration.converter;
 
-public class IntegerValueConverter implements ValueConverter<Integer> {
+public class IntegerValueConverter extends AbstractValueConverter<Integer> {
 
 	public static final IntegerValueConverter INSTANCE = new IntegerValueConverter();
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/JsonValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/JsonValueConverter.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public class JsonValueConverter<T> implements ValueConverter<T> {
+public class JsonValueConverter<T> extends AbstractValueConverter<T> {
 
 	private final TypeReference<T> typeReference;
 	private final ObjectMapper objectMapper;

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ListValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ListValueConverter.java
@@ -1,14 +1,12 @@
 package org.stagemonitor.configuration.converter;
 
-import org.stagemonitor.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
 
-public class ListValueConverter<T> implements ValueConverter<List<T>> {
+public class ListValueConverter<T> extends AbstractCollectionValueConverter<List<T>, T> {
 
 	public static final ListValueConverter<String> STRINGS_VALUE_CONVERTER =
 			new ListValueConverter<String>(StringValueConverter.INSTANCE);
@@ -19,10 +17,9 @@ public class ListValueConverter<T> implements ValueConverter<List<T>> {
 	public static final ValueConverter<List<Integer>> INTEGERS =
 			new ListValueConverter<Integer>(IntegerValueConverter.INSTANCE);
 
-	private final ValueConverter<T> valueConverter;
 
 	public ListValueConverter(ValueConverter<T> valueConverter) {
-		this.valueConverter = valueConverter;
+		super(valueConverter);
 	}
 
 	@Override
@@ -37,10 +34,6 @@ public class ListValueConverter<T> implements ValueConverter<List<T>> {
 		return emptyList();
 	}
 
-	@Override
-	public String toString(List<T> value) {
-		return StringUtils.asCsv(value);
-	}
 
 }
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/LongValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/LongValueConverter.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.configuration.converter;
 
-public class LongValueConverter implements ValueConverter<Long> {
+public class LongValueConverter extends AbstractValueConverter<Long> {
 
 	public static final LongValueConverter INSTANCE = new LongValueConverter();
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/MapValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/MapValueConverter.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public class MapValueConverter<K, V> implements ValueConverter<Map<K, V>> {
+public class MapValueConverter<K, V> extends AbstractValueConverter<Map<K, V>> {
 
 	private final ValueConverter<K> keyValueConverter;
 	private final ValueConverter<V> valueValueConverter;
@@ -54,13 +54,26 @@ public class MapValueConverter<K, V> implements ValueConverter<Map<K, V>> {
 
 	@Override
 	public String toString(Map<K, V> value) {
-		if (value == null) {
+		return getString(value, false);
+	}
+
+	@Override
+	public String toSafeString(Map<K, V> value) {
+		return getString(value, true);
+	}
+
+	private String getString(Map<K, V> map, boolean safeString) {
+		if (map == null) {
 			return null;
 		}
 		StringBuilder sb = new StringBuilder();
-		for (Iterator<Map.Entry<K, V>> iterator = value.entrySet().iterator(); iterator.hasNext(); ) {
+		for (Iterator<Map.Entry<K, V>> iterator = map.entrySet().iterator(); iterator.hasNext(); ) {
 			Map.Entry<K, V> entry = iterator.next();
-			sb.append(keyValueConverter.toString(entry.getKey())).append(valueSeparator).append(' ').append(valueValueConverter.toString(entry.getValue()));
+			final K key = entry.getKey();
+			final V value = entry.getValue();
+			sb.append(safeString ? keyValueConverter.toSafeString(key) : keyValueConverter.toString(key))
+					.append(valueSeparator).append(' ')
+					.append(safeString ? valueValueConverter.toSafeString(value) : valueValueConverter.toString(value));
 			if (iterator.hasNext()) {
 				sb.append(entrySeparator).append('\n');
 			}

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/OptionalValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/OptionalValueConverter.java
@@ -2,7 +2,7 @@ package org.stagemonitor.configuration.converter;
 
 import java.util.Optional;
 
-public class OptionalValueConverter<T> implements ValueConverter<Optional<T>> {
+public class OptionalValueConverter<T> extends AbstractValueConverter<Optional<T>> {
 
 	private final ValueConverter<T> valueConverter;
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/RegexValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/RegexValueConverter.java
@@ -3,7 +3,7 @@ package org.stagemonitor.configuration.converter;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-public class RegexValueConverter implements ValueConverter<Pattern> {
+public class RegexValueConverter extends AbstractValueConverter<Pattern> {
 
 	public static final RegexValueConverter INSTANCE = new RegexValueConverter();
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/SetValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/SetValueConverter.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import static java.util.Collections.emptySet;
 
-public class SetValueConverter<T> implements ValueConverter<Collection<T>> {
+public class SetValueConverter<T> extends AbstractCollectionValueConverter<Collection<T>, T> {
 
 	public static final SetValueConverter<String> STRINGS_VALUE_CONVERTER =
 			new SetValueConverter<String>(StringValueConverter.INSTANCE);
@@ -21,10 +21,8 @@ public class SetValueConverter<T> implements ValueConverter<Collection<T>> {
 	public static final ValueConverter<Collection<Integer>> INTEGERS =
 			new SetValueConverter<Integer>(IntegerValueConverter.INSTANCE);
 
-	private final ValueConverter<T> valueConverter;
-
 	public SetValueConverter(ValueConverter<T> valueConverter) {
-		this.valueConverter = valueConverter;
+		super(valueConverter);
 	}
 
 	@Override

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/StringValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/StringValueConverter.java
@@ -1,6 +1,6 @@
 package org.stagemonitor.configuration.converter;
 
-public class StringValueConverter implements ValueConverter<String> {
+public class StringValueConverter extends AbstractValueConverter<String> {
 
 	public static final StringValueConverter INSTANCE = new StringValueConverter(false);
 

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/UrlValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/UrlValueConverter.java
@@ -1,0 +1,50 @@
+package org.stagemonitor.configuration.converter;
+
+import org.stagemonitor.util.StringUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class UrlValueConverter extends AbstractValueConverter<URL> {
+
+	public static final ValueConverter<URL> INSTANCE = new UrlValueConverter();
+
+	private UrlValueConverter() {
+	}
+
+	@Override
+	public URL convert(String s) throws IllegalArgumentException {
+		try {
+			return new URL(StringUtils.removeTrailingSlash(s));
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException(e.getMessage());
+		}
+	}
+
+	@Override
+	public String toString(URL value) {
+		if (value == null) {
+			return null;
+		}
+		return value.toString();
+	}
+
+	@Override
+	public String toSafeString(URL value) {
+		if (value == null) {
+			return null;
+		}
+		final String userInfo = value.getUserInfo();
+		final String urlAsString = value.toString();
+		if (userInfo != null) {
+			return urlAsString.replace(userInfo, getSafeUserInfo(userInfo));
+		} else {
+			return urlAsString;
+		}
+	}
+
+	private String getSafeUserInfo(String userInfo) {
+		return userInfo.split(":", 2)[0] + ":XXX";
+	}
+
+}

--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ValueConverter.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/configuration/converter/ValueConverter.java
@@ -18,4 +18,12 @@ public interface ValueConverter<T> {
 	 * @return the configuration value in its string representation
 	 */
 	String toString(T value);
+
+	/**
+	 * Converts a value to a string, redacting all sensitive information specific to the value type.
+	 *
+	 * <p>For example, when the value type {@link T} is of type {@link java.net.URL} this method should redact the
+	 * password in the {@link java.net.URL#userInfo}</p>
+	 */
+	String toSafeString(T value);
 }

--- a/stagemonitor-configuration/src/test/java/org/stagemonitor/configuration/converter/UrlValueConverterTest.java
+++ b/stagemonitor-configuration/src/test/java/org/stagemonitor/configuration/converter/UrlValueConverterTest.java
@@ -1,0 +1,64 @@
+package org.stagemonitor.configuration.converter;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class UrlValueConverterTest {
+
+	private final ValueConverter<URL> converter = UrlValueConverter.INSTANCE;
+
+	@Test
+	public void testConvert() throws Exception {
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(converter.toString(converter.convert("http://www.example.com"))).isEqualTo("http://www.example.com");
+			softly.assertThat(converter.toString(converter.convert("http://www.example.com/"))).isEqualTo("http://www.example.com");
+			softly.assertThat(converter.toString(converter.convert("http://www.example.com/"))).isEqualTo("http://www.example.com");
+			softly.assertThat(converter.convert("http://user:pwd@www.example.com").getUserInfo()).isEqualTo("user:pwd");
+		});
+	}
+
+	@Test
+	public void testToSafeString() throws Exception {
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(converter.toSafeString(converter.convert("http://user:pwd@www.example.com"))).isEqualTo("http://user:XXX@www.example.com");
+			softly.assertThat(converter.toSafeString(converter.convert("https://user:pw:d@www.example.com"))).isEqualTo("https://user:XXX@www.example.com");
+		});
+	}
+
+	@Test
+	public void testToSafeStringList() throws Exception {
+		final ListValueConverter<URL> urlListValueConverter = new ListValueConverter<>(converter);
+		assertThat(urlListValueConverter.toSafeString(urlListValueConverter.convert("http://user:pwd@www.example.com,https://user:pw:d@www.example.com")))
+				.isEqualTo("http://user:XXX@www.example.com,https://user:XXX@www.example.com");
+	}
+
+	@Test
+	public void testConvertNull() throws Exception {
+		assertThatThrownBy(() -> converter.convert(null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void testConvertInvalid() throws Exception {
+		assertThatThrownBy(() -> converter.convert("invalid"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void testConvertNoProtocol() throws Exception {
+		assertThatThrownBy(() -> converter.convert("www.example.com"))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("no protocol");
+	}
+
+	@Test
+	public void testToStringNull() throws Exception {
+		assertThat(converter.toString(null)).isNull();
+	}
+
+}

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/Stagemonitor.java
@@ -15,7 +15,6 @@ import org.stagemonitor.core.metrics.health.ImmediateResult;
 import org.stagemonitor.core.metrics.health.OverridableHealthCheckRegistry;
 import org.stagemonitor.core.metrics.metrics2.Metric2Registry;
 import org.stagemonitor.core.util.ClassUtils;
-import org.stagemonitor.core.util.HttpClient;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -155,14 +154,7 @@ public final class Stagemonitor {
 		if (option.isSensitive()) {
 			return "XXXX";
 		} else {
-			String trimmedValue = HttpClient.removeUserInfo(option.getValueAsString());
-			trimmedValue = trimmedValue.replace("\n", "");
-
-			int maximumLineLength = 55;
-			if (trimmedValue.length() > maximumLineLength) {
-				trimmedValue = trimmedValue.substring(0, maximumLineLength - 3) + "...";
-			}
-			return trimmedValue;
+			return option.getValueAsSafeString();
 		}
 	}
 

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/elasticsearch/ElasticsearchClient.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/elasticsearch/ElasticsearchClient.java
@@ -23,7 +23,6 @@ import org.stagemonitor.core.util.http.HttpRequestBuilder;
 import org.stagemonitor.core.util.http.NoopResponseHandler;
 import org.stagemonitor.core.util.http.StatusCodeResponseHandler;
 import org.stagemonitor.util.IOUtils;
-import org.stagemonitor.util.StringUtils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -294,7 +293,7 @@ public class ElasticsearchClient {
 			return;
 		}
 		final String url = corePlugin.getElasticsearchUrl() + "/" + indexPattern + "/_settings?ignore_unavailable=true";
-		logger.info("Updating index settings {}\n{}", HttpClient.removeUserInfo(url), settings);
+		logger.info("Updating index settings {}\n{}", indexPattern, settings);
 		httpClient.send(HttpRequestBuilder.<Integer>jsonRequest("PUT", url, settings)
 				.responseHandler(new StatusCodeResponseHandler(new ErrorLoggingResponseHandler()))
 				.build());
@@ -305,12 +304,11 @@ public class ElasticsearchClient {
 			return;
 		}
 		final String url = corePlugin.getElasticsearchUrl() + "/" + path;
-		String urlWithoutAuthInfo = HttpClient.removeUserInfo(url);
-		logger.info(logMessage, urlWithoutAuthInfo);
+		logger.info(logMessage, path);
 		try {
 			send(HttpRequestBuilder.forUrl(url).method(method).build());
 		} finally {
-			logger.info(logMessage, "Done " + urlWithoutAuthInfo);
+			logger.info(logMessage, "Done " + path);
 		}
 	}
 
@@ -382,7 +380,7 @@ public class ElasticsearchClient {
 		return httpClient;
 	}
 
-	public String getElasticsearchUrl() {
+	public URL getElasticsearchUrl() {
 		return corePlugin.getElasticsearchUrl();
 	}
 
@@ -545,8 +543,8 @@ public class ElasticsearchClient {
 			// TODO actually, the availability check has to be performed for each URL as multiple ES urls can be configured
 			// in the future, detect all available nodes in the cluster: http://{oneOfTheProvidedUrls}/_nodes/box_type:hot/none
 			// -> response.nodes*.http_address
-			final String elasticsearchUrl = corePlugin.getElasticsearchUrl();
-			if (StringUtils.isEmpty(elasticsearchUrl)) {
+			final URL elasticsearchUrl = corePlugin.getElasticsearchUrl();
+			if (elasticsearchUrl == null) {
 				return;
 			}
 			httpClient.send(HttpRequestBuilder.<Void>forUrl(elasticsearchUrl + "/")

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/grafana/GrafanaClient.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/grafana/GrafanaClient.java
@@ -15,6 +15,7 @@ import org.stagemonitor.util.IOUtils;
 import org.stagemonitor.util.StringUtils;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -47,10 +48,10 @@ public class GrafanaClient {
 				.createSingleThreadDeamonPool("async-grafana", corePlugin.getThreadPoolQueueCapacityLimit(), corePlugin);
 	}
 
-	public void createElasticsearchDatasource(final String url) {
+	public void createElasticsearchDatasource(final URL elasticsearchUrl) {
 		Map<String, Object> dataSource = new HashMap<String, Object>();
 		dataSource.put("name", ES_STAGEMONITOR_DS_NAME);
-		dataSource.put("url", url);
+		dataSource.put("url", elasticsearchUrl.toString());
 		dataSource.put("access", "proxy");
 		dataSource.put("database", "[stagemonitor-metrics-]YYYY.MM.DD");
 		dataSource.put("isDefault", false);

--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/MetricNameValueConverter.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/metrics/metrics2/MetricNameValueConverter.java
@@ -1,8 +1,8 @@
 package org.stagemonitor.core.metrics.metrics2;
 
-import org.stagemonitor.configuration.converter.ValueConverter;
+import org.stagemonitor.configuration.converter.AbstractValueConverter;
 
-public class MetricNameValueConverter implements ValueConverter<MetricName> {
+public class MetricNameValueConverter extends AbstractValueConverter<MetricName> {
 	@Override
 	public MetricName convert(String s) throws IllegalArgumentException {
 		return MetricName.name(s).build();

--- a/stagemonitor-core/src/test/java/org/stagemonitor/AbstractElasticsearchTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/AbstractElasticsearchTest.java
@@ -20,6 +20,7 @@ import org.stagemonitor.core.util.HttpClient;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -34,7 +35,7 @@ public class AbstractElasticsearchTest {
 	protected static AdminClient adminClient;
 	protected static int elasticsearchPort;
 	protected static ElasticsearchClient elasticsearchClient;
-	protected static String elasticsearchUrl;
+	protected static URL elasticsearchUrl;
 	protected static CorePlugin corePlugin;
 
 	@BeforeClass
@@ -54,7 +55,7 @@ public class AbstractElasticsearchTest {
 					.put("transport.type", "local")
 					.put("http.type", "netty4")
 					.build();
-			elasticsearchUrl = "http://localhost:" + elasticsearchPort;
+			elasticsearchUrl = new URL("http://localhost:" + elasticsearchPort);
 			AbstractElasticsearchTest.corePlugin = mock(CorePlugin.class);
 			when(corePlugin.getElasticsearchUrl()).thenReturn(elasticsearchUrl);
 			when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList(elasticsearchUrl));

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/CorePluginTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/CorePluginTest.java
@@ -13,7 +13,6 @@ import java.io.Closeable;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
@@ -27,12 +26,12 @@ public class CorePluginTest {
 						.add("stagemonitor.reporting.elasticsearch.url", "http://bla:1/,http://bla:2,http://bla:3")),
 				null).getConfig(CorePlugin.class);
 
-		assertEquals("http://bla:1", corePlugin.getElasticsearchUrl());
-		assertEquals("http://bla:2", corePlugin.getElasticsearchUrl());
-		assertEquals("http://bla:3", corePlugin.getElasticsearchUrl());
-		assertEquals("http://bla:1", corePlugin.getElasticsearchUrl());
-		assertEquals("http://bla:2", corePlugin.getElasticsearchUrl());
-		assertEquals("http://bla:3", corePlugin.getElasticsearchUrl());
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:1");
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:2");
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:3");
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:1");
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:2");
+		assertThat(corePlugin.getElasticsearchUrl().toString()).isEqualTo("http://bla:3");
 	}
 
 	@Test
@@ -43,7 +42,7 @@ public class CorePluginTest {
 						.add("stagemonitor.reporting.elasticsearch.url", "http://user:password@bla:1")),
 				null).getConfig(CorePlugin.class);
 
-		assertThat(corePlugin.getElasticsearchUrlsWithoutAuthenticationInformation()).containsExactly("http://XXXX:XXXX@bla:1");
+		assertThat(corePlugin.getElasticsearchUrlsWithoutAuthenticationInformation()).isEqualTo("http://user:XXX@bla:1");
 	}
 
 	@Test

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/elasticsearch/ElasticsearchClientAvailabilityCheckTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/elasticsearch/ElasticsearchClientAvailabilityCheckTest.java
@@ -9,6 +9,7 @@ import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.util.HttpClient;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Collections;
 
 import javax.servlet.ServletException;
@@ -27,8 +28,9 @@ public class ElasticsearchClientAvailabilityCheckTest {
 	@Before
 	public void setUp() throws Exception {
 		final CorePlugin corePlugin = mock(CorePlugin.class);
-		when(corePlugin.getElasticsearchUrl()).thenReturn("http://localhost:41234");
-		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList("http://localhost:41234"));
+		final URL url = new URL("http://localhost:41234");
+		when(corePlugin.getElasticsearchUrl()).thenReturn(url);
+		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList(url));
 		when(corePlugin.getThreadPoolQueueCapacityLimit()).thenReturn(10000);
 		elasticsearchClient = new ElasticsearchClient(corePlugin, new HttpClient(), 1);
 	}

--- a/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporterTest.java
+++ b/stagemonitor-core/src/test/java/org/stagemonitor/core/metrics/metrics2/InfluxDbReporterTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.stagemonitor.core.CorePlugin;
 import org.stagemonitor.core.util.HttpClient;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -46,7 +47,7 @@ public class InfluxDbReporterTest {
 		timestamp = System.currentTimeMillis();
 		when(clock.getTime()).thenReturn(timestamp);
 		final CorePlugin corePlugin = mock(CorePlugin.class);
-		when(corePlugin.getInfluxDbUrl()).thenReturn("http://localhost:8086");
+		when(corePlugin.getInfluxDbUrl()).thenReturn(new URL("http://localhost:8086"));
 		when(corePlugin.getInfluxDbDb()).thenReturn("stm");
 		influxDbReporter = InfluxDbReporter.forRegistry(new Metric2Registry(), corePlugin)
 				.convertRatesTo(TimeUnit.SECONDS)

--- a/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/AbstractElasticsearchSpanReporterTest.java
+++ b/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/AbstractElasticsearchSpanReporterTest.java
@@ -22,6 +22,7 @@ import org.stagemonitor.tracing.sampling.SamplePriorityDeterminingSpanEventListe
 import org.stagemonitor.tracing.utils.SpanUtils;
 import org.stagemonitor.tracing.wrapper.SpanWrappingTracer;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,8 +75,9 @@ public class AbstractElasticsearchSpanReporterTest {
 		when(tracingPlugin.getProfilerRateLimitPerMinute()).thenReturn(1_000_000d);
 		when(tracingPlugin.getCallTreeAsciiFormatter()).thenReturn(new ShortSignatureFormatter());
 		when(tracingPlugin.isSampled(any())).then(invocation -> new DefaultTracerFactory().isSampled(invocation.getArgument(0)));
-		when(corePlugin.getElasticsearchUrl()).thenReturn("http://localhost:9200");
-		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList("http://localhost:9200"));
+		final URL url = new URL("http://localhost:9200");
+		when(corePlugin.getElasticsearchUrl()).thenReturn(url);
+		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList(url));
 		when(corePlugin.getElasticsearchClient()).thenReturn(elasticsearchClient = mock(ElasticsearchClient.class));
 		when(corePlugin.getThreadPoolQueueCapacityLimit()).thenReturn(1000);
 		when(elasticsearchClient.isElasticsearchAvailable()).thenReturn(true);

--- a/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/eum/ClientSpanMetadataTagProcessor.java
+++ b/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/eum/ClientSpanMetadataTagProcessor.java
@@ -2,8 +2,8 @@ package org.stagemonitor.web.servlet.eum;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.stagemonitor.configuration.converter.AbstractValueConverter;
 import org.stagemonitor.configuration.converter.DoubleValueConverter;
-import org.stagemonitor.configuration.converter.ValueConverter;
 import org.stagemonitor.web.servlet.ServletPlugin;
 
 import java.util.Map;
@@ -105,7 +105,7 @@ public class ClientSpanMetadataTagProcessor extends ClientSpanTagProcessor {
 		}
 	}
 
-	public static class ClientSpanMetadataConverter implements ValueConverter<ClientSpanMetadataDefinition>	{
+	public static class ClientSpanMetadataConverter extends AbstractValueConverter<ClientSpanMetadataDefinition> {
 
 		@Override
 		public ClientSpanMetadataDefinition convert(String definition) throws IllegalArgumentException {

--- a/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/MonitoredHttpRequestDoNotTrackTest.java
+++ b/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/MonitoredHttpRequestDoNotTrackTest.java
@@ -15,6 +15,7 @@ import org.stagemonitor.tracing.wrapper.SpanWrapper;
 import org.stagemonitor.tracing.wrapper.SpanWrappingTracer;
 import org.stagemonitor.web.servlet.filter.StatusExposingByteCountingServletResponse;
 
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
@@ -47,8 +48,9 @@ public class MonitoredHttpRequestDoNotTrackTest {
 		when(configuration.getConfig(ServletPlugin.class)).thenReturn(servletPlugin);
 		when(tracingPlugin.getDefaultRateLimitSpansPerMinute()).thenReturn(1000000d);
 		when(tracingPlugin.getOnlyReportSpansWithName()).thenReturn(Collections.emptyList());
-		when(corePlugin.getElasticsearchUrl()).thenReturn("http://localhost:9200");
-		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList("http://localhost:9200"));
+		final URL url = new URL("http://localhost:9200");
+		when(corePlugin.getElasticsearchUrl()).thenReturn(url);
+		when(corePlugin.getElasticsearchUrls()).thenReturn(Collections.singletonList(url));
 		ElasticsearchClient elasticsearchClient = mock(ElasticsearchClient.class);
 		when(elasticsearchClient.isElasticsearchAvailable()).thenReturn(true);
 		when(corePlugin.getElasticsearchClient()).thenReturn(elasticsearchClient);


### PR DESCRIPTION
- Introduces a UrlValueConverter which is able to redact
  the password from urls like http://user:pwd@example.com
- This now also works for configuration options which are
  a list of urls. The previous mechanism failed when there
  where multiple URLs.
- ConfigurationOption now has a getValueAsSafeString() method