### PR TITLE
#issue 376 : problems with transitive dependencies from jaeger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ ext {
 	jacksonVersion = '2.9.0'
 	esVersion = '6.1.1'
 	byteBuddyVersion = '1.7.9'
-	opentracingVersion = '0.31.0-RC1'
-	jaegerVersion = '0.22.0-RC1'
+	opentracingVersion = '0.31.0'
+	jaegerVersion = '0.23.0'
 	jettyVersion = '9.3.13.v20161014'
 	getProjectsToRelease = this.&getProjectsToRelease
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ ext {
 	esVersion = '6.1.1'
 	byteBuddyVersion = '1.7.9'
 	opentracingVersion = '0.31.0'
-	jaegerVersion = '0.23.0'
+	jaegerVersion = '0.24.0'
 	jettyVersion = '9.3.13.v20161014'
 	getProjectsToRelease = this.&getProjectsToRelease
 }

--- a/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/impl/JaegerTracerFactoryTest.java
+++ b/stagemonitor-tracing-elasticsearch/src/test/java/org/stagemonitor/tracing/elasticsearch/impl/JaegerTracerFactoryTest.java
@@ -20,8 +20,8 @@ public class JaegerTracerFactoryTest {
 				new MeasurementSession("JaegerTracerFactoryTest", "test", "test"));
 		final JaegerTracerFactory jaegerTracerFactory = new JaegerTracerFactory();
 		final Tracer tracer = jaegerTracerFactory.getTracer(initArguments);
-		try (final Scope rootSpan = tracer.buildSpan("foo").startActive()) {
-			try (final Scope childSpan = tracer.buildSpan("bar").startActive()) {
+		try (final Scope rootSpan = tracer.buildSpan("foo").startActive(true)) {
+			try (final Scope childSpan = tracer.buildSpan("bar").startActive(true)) {
 				assertThat(jaegerTracerFactory.isRoot(rootSpan.span())).isTrue();
 				assertThat(jaegerTracerFactory.isRoot(childSpan.span())).isFalse();
 			}

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/AbstractExternalRequest.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/AbstractExternalRequest.java
@@ -38,7 +38,7 @@ public abstract class AbstractExternalRequest extends MonitoredRequest {
 			spanBuilder.withTag(MetricsSpanEventListener.ENABLE_TRACKING_METRICS_TAG, true);
 		}
 		spanBuilder.withTag(SpanUtils.OPERATION_TYPE, getType());
-		return spanBuilder.startActive();
+		return spanBuilder.startActive(true);
 	}
 
 	protected abstract String getType();

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/MonitoredMethodRequest.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/MonitoredMethodRequest.java
@@ -56,7 +56,7 @@ public class MonitoredMethodRequest extends MonitoredRequest {
 		final Scope scope = spanBuilder
 				.withTag(SpanUtils.OPERATION_TYPE, OP_TYPE_METHOD_INVOCATION)
 				.withTag(MetricsSpanEventListener.ENABLE_TRACKING_METRICS_TAG, true)
-				.startActive();
+				.startActive(true);
 		SpanUtils.setParameters(scope.span(), safeParameters);
 		return scope;
 	}

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/impl/DefaultTracerImpl.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/impl/DefaultTracerImpl.java
@@ -1,6 +1,7 @@
 package org.stagemonitor.tracing.impl;
 
 import io.opentracing.ScopeManager;
+import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
@@ -20,6 +21,11 @@ class DefaultTracerImpl implements Tracer {
 	public ScopeManager scopeManager() {
 		return scopeManager;
 	}
+    
+    @Override
+    public Span activeSpan() {
+        return scopeManager.active().span();
+    }
 
 	@Override
 	public SpanBuilder buildSpan(String operationName) {

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/soap/TracingClientSOAPHandler.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/soap/TracingClientSOAPHandler.java
@@ -29,7 +29,7 @@ public class TracingClientSOAPHandler extends AbstractTracingSOAPHandler {
 		if (soapTracingPlugin.isSoapClientRecordRequestMessages()) {
 			spanBuilder.withTag("soap.request", getSoapMessageAsString(context));
 		}
-		final Span span = spanBuilder.startActive().span();
+		final Span span = spanBuilder.startActive(true).span();
 		tracingPlugin.getTracer().inject(span.context(), Format.Builtin.HTTP_HEADERS, new SOAPMessageInjectAdapter(context));
 	}
 

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/soap/TracingServerSOAPHandler.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/soap/TracingServerSOAPHandler.java
@@ -34,7 +34,7 @@ public class TracingServerSOAPHandler extends AbstractTracingSOAPHandler {
 		if (soapTracingPlugin.isSoapServerRecordRequestMessages()) {
 			spanBuilder.withTag("soap.request", getSoapMessageAsString(context));
 		}
-		spanBuilder.startActive();
+		spanBuilder.startActive(true);
 	}
 
 	@Override

--- a/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/wrapper/SpanWrappingTracer.java
+++ b/stagemonitor-tracing/src/main/java/org/stagemonitor/tracing/wrapper/SpanWrappingTracer.java
@@ -40,6 +40,11 @@ public class SpanWrappingTracer implements Tracer {
 	public ScopeManager scopeManager() {
 		return delegate.scopeManager();
 	}
+    
+    @Override
+    public Span activeSpan() {
+        return scopeManager().active().span();
+    }
 
 	@Override
 	public SpanWrappingSpanBuilder buildSpan(String operationName) {
@@ -155,11 +160,6 @@ public class SpanWrappingTracer implements Tracer {
 			startTimestampMillis = TimeUnit.MICROSECONDS.toMillis(microseconds);
 			delegate = delegate.withStartTimestamp(microseconds);
 			return this;
-		}
-
-		@Override
-		public Scope startActive() {
-			return scopeManager().activate(startManual());
 		}
 
 		@Override

--- a/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/MonitoredHttpRequest.java
+++ b/stagemonitor-web-servlet/src/main/java/org/stagemonitor/web/servlet/MonitoredHttpRequest.java
@@ -96,7 +96,7 @@ public class MonitoredHttpRequest extends MonitoredRequest {
 			spanBuilder = spanBuilder.withTag(Tags.SAMPLING_PRIORITY.getKey(), 0);
 		}
 		spanBuilder.withTag(SpanUtils.OPERATION_TYPE, "http");
-		final Scope scope = spanBuilder.startActive();
+		final Scope scope = spanBuilder.startActive(true);
 		final Span span = scope.span();
 		Tags.HTTP_URL.set(span, httpServletRequest.getRequestURI());
 		Tags.PEER_PORT.set(span, httpServletRequest.getRemotePort());


### PR DESCRIPTION
From 0.30.0 to 0.31.0 they have made some changes, https://github.com/opentracing/opentracing-java/pull/251/files
Highlights are : 
- https://github.com/opentracing/opentracing-java/pull/219 
- a new method in Tracer, activeSpan
- SpanBuilder's startActive removed

Last but not least, found that someone has created a compatibility layer for 0.30.0 API, more info:
https://github.com/opentracing/opentracing-java/pull/221
They finally decided to create it as an external library https://github.com/opentracing/opentracing-java-v030/, which is already on maven central
https://mvnrepository.com/artifact/io.opentracing/opentracing-v030/0.0.4