### PR TITLE
always schedule metrics index management

### DIFF
--- a/stagemonitor-core/src/main/java/org/stagemonitor/core/CoreElasticsearchInitializer.java
+++ b/stagemonitor-core/src/main/java/org/stagemonitor/core/CoreElasticsearchInitializer.java
@@ -31,6 +31,9 @@ public class CoreElasticsearchInitializer extends AbstractElasticsearchInitializ
 			manageMetricsIndex(elasticsearchClient, corePlugin);
 		}
 
+		elasticsearchClient.scheduleIndexManagement(ElasticsearchReporter.STAGEMONITOR_METRICS_INDEX_PREFIX,
+				corePlugin.getMoveToColdNodesAfterDays(), corePlugin.getDeleteElasticsearchMetricsAfterDays());
+
 		reportToElasticsearch(corePlugin.getMetricRegistry(), corePlugin.getReportingIntervalElasticsearch(), corePlugin.getMeasurementSession());
 	}
 
@@ -62,8 +65,6 @@ public class CoreElasticsearchInitializer extends AbstractElasticsearchInitializ
 					corePlugin.getMetricsIndexTemplate(), corePlugin.getMoveToColdNodesAfterDays(), corePlugin.getNumberOfReplicas(), corePlugin.getNumberOfShards());
 			elasticsearchClient.sendMappingTemplate(mappingJson, "stagemonitor-metrics");
 			elasticsearchClient.createEmptyIndex(ElasticsearchReporter.getTodaysIndexName());
-			elasticsearchClient.scheduleIndexManagement(ElasticsearchReporter.STAGEMONITOR_METRICS_INDEX_PREFIX,
-					corePlugin.getMoveToColdNodesAfterDays(), corePlugin.getDeleteElasticsearchMetricsAfterDays());
 		}
 	}
 


### PR DESCRIPTION
The index management (moving to cold nodes, deleting old indices) should always be scheduled. At the moment, it is always scheduled for the spans index, but not for the metrics index.