### PR TITLE
fixed jaeger NumberFormatException issue

### DIFF
--- a/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/MonitoredHttpRequestTest.java
+++ b/stagemonitor-web-servlet/src/test/java/org/stagemonitor/web/servlet/MonitoredHttpRequestTest.java
@@ -1,6 +1,7 @@
 package org.stagemonitor.web.servlet;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockFilterChain;
@@ -101,6 +102,24 @@ public class MonitoredHttpRequestTest {
 		assertEquals("blubb", mockSpan.tags().get(SpanUtils.PARAMETERS_PREFIX + "bla"));
 		assertEquals("XXXX", mockSpan.tags().get(SpanUtils.PARAMETERS_PREFIX + "pwd"));
 		assertEquals("XXXX", mockSpan.tags().get(SpanUtils.PARAMETERS_PREFIX + "creditCard"));
+		assertFalse(mockSpan.tags().containsKey(Tags.ERROR.getKey()));
+	}
+
+	@Test
+	public void testNumberFormatExceptionCreateSpan() throws Exception {
+		final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test.js");
+		request.addHeader("spanid", "<script>alert(1);</script>");
+		request.addHeader("traceid", "42");
+
+		final MonitoredHttpRequest monitoredHttpRequest = createMonitoredHttpRequest(request);
+
+		monitoredHttpRequest.createScope().close();
+		assertEquals(1, tracer.finishedSpans().size());
+		final MockSpan mockSpan = tracer.finishedSpans().get(0);
+		assertEquals("/test.js", mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+		assertEquals("GET *.js", mockSpan.operationName());
+		assertEquals("GET", mockSpan.tags().get("method"));
+
 		assertFalse(mockSpan.tags().containsKey(Tags.ERROR.getKey()));
 	}
 


### PR DESCRIPTION
Passing an invalid X-B3-SpanId header value leads to a NumberFormatException in jaeger with could be returned to the caller. If the invalid header value is a JavaScript method, the method is executed by the browser.