### PR TITLE
#416 Optimize performance, reduce GC pressure from massive DateFormat instance creation in StringUtils

### DIFF
--- a/stagemonitor-configuration/src/main/java/org/stagemonitor/util/StringUtils.java
+++ b/stagemonitor-configuration/src/main/java/org/stagemonitor/util/StringUtils.java
@@ -18,6 +18,10 @@ public class StringUtils {
 	private static final Pattern CAMEL_CASE = Pattern.compile("(?<=[A-Z])(?=[A-Z][a-z])|(?<=[^A-Z])(?=[A-Z])|(?<=[A-Za-z])(?=[^A-Za-z])");
 	private static final char[] hexArray = "0123456789abcdef".toCharArray();
 
+	private static final ThreadLocal<DateFormat> LOGSTASH_STYLE_FORMAT = new ThreadLocal<DateFormat>();
+
+	private static final ThreadLocal<DateFormat> ISO_STRING_FORMAT = new ThreadLocal<DateFormat>();
+
 	private StringUtils() {
 	}
 
@@ -93,10 +97,12 @@ public class StringUtils {
 	}
 
 	public static String dateAsIsoString(Date date) {
-		TimeZone tz = TimeZone.getDefault();
-		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-		df.setTimeZone(tz);
-		return df.format(date);
+		DateFormat dateFormat = ISO_STRING_FORMAT.get();
+		if (dateFormat == null) {
+			dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+			dateFormat.setTimeZone(TimeZone.getDefault());
+		}
+		return dateFormat.format(date);
 	}
 
 	public static String timestampAsIsoString(long timestamp) {
@@ -133,8 +139,12 @@ public class StringUtils {
 	}
 
 	public static String getLogstashStyleDate(long time) {
-		final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd");
-		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		DateFormat dateFormat = LOGSTASH_STYLE_FORMAT.get();
+		if (dateFormat == null) {
+			dateFormat = new SimpleDateFormat("yyyy.MM.dd");
+			dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+			LOGSTASH_STYLE_FORMAT.set(dateFormat);
+		}
 		return dateFormat.format(new Date(time));
 	}
 


### PR DESCRIPTION
The single line in StringUtils#getLogstashStyleDate(long) produces about 7-8% of total stagemonitor TLAB allocation (GC pressure) in my production system.

The optimization is pretty trivial: wrap stateful DateFormat instances into ThreadLocal that is safely initialized and accessed per thread.

Please find allocation [flamegraph](http://www.brendangregg.com/flamegraphs.html) below, bar widths are proportional to total (TLAB + outside TLAB) allocation in the heap. 

![image](https://user-images.githubusercontent.com/165260/42850721-95f3d3a4-89ee-11e8-9551-09103fd2769f.png)

From this perspective, `new SimpleDateFormat(..)` looks like a very expensive line of code, right?

