### PR TITLE
#421 Reuse Jackson write buffers by closing JsonGenerator in ElasticsearchReporter

### DIFF
--- a/stagemonitor-benchmark/build.gradle
+++ b/stagemonitor-benchmark/build.gradle
@@ -1,21 +1,32 @@
 plugins {
-	id 'me.champeau.gradle.jmh' version '0.3.0'
+	id "me.champeau.gradle.jmh" version "0.4.7"
 }
 
-apply plugin: 'me.champeau.gradle.jmh'
-
 jmh {
-	jmhVersion = '1.12'
+	jmhVersion = '1.21'
 	iterations = 5
 	fork = 2
 	warmupIterations = 1
 	warmupForks = 1
-	benchmarkMode = 'AverageTime'
+	benchmarkMode = ['AverageTime']
 	humanOutputFile = null
 	timeUnit = 'ns'
 	include = '.*MetricNameBenchmark.*'
 //	profilers = ['hs_gc']
 	//	mergeServiceFiles()
+}
+
+jmh {
+	jmhVersion = '1.21'
+	iterations = 1
+	fork = 1
+	warmupIterations = 1
+	warmupForks = 1
+	benchmarkMode = ['AverageTime']
+	timeUnit = 'ns'
+	include = '.*ElasticsearchReporterBenchmark.*'
+	jvmArgs = "$System.env.JMH_ARGS"
+	profilers = ['gc']
 }
 
 dependencies {

--- a/stagemonitor-benchmark/src/jmh/java/org/stagemonitor/ElasticsearchReporterBenchmark.java
+++ b/stagemonitor-benchmark/src/jmh/java/org/stagemonitor/ElasticsearchReporterBenchmark.java
@@ -1,0 +1,88 @@
+package org.stagemonitor;
+
+import com.codahale.metrics.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.stagemonitor.core.CorePlugin;
+import org.stagemonitor.core.elasticsearch.ElasticsearchClient;
+import org.stagemonitor.core.metrics.metrics2.ElasticsearchReporter;
+import org.stagemonitor.core.metrics.metrics2.Metric2Registry;
+import org.stagemonitor.core.metrics.metrics2.MetricName;
+import org.stagemonitor.core.util.HttpClient;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.stagemonitor.core.metrics.metrics2.MetricName.name;
+
+@State(value = Scope.Benchmark)
+public class ElasticsearchReporterBenchmark {
+
+	private static final TimeUnit DURATION_UNIT = TimeUnit.MICROSECONDS;
+	private static final byte[] bulkActionBytes = new byte[] {};
+
+	private ElasticsearchReporter elasticsearchReporter;
+	private ByteArrayOutputStream out;
+	private CorePlugin corePlugin;
+	private Metric2Registry registry;
+	private long timestamp;
+
+	private Map<MetricName, Gauge> gauges;
+	private Map<MetricName, Counter> counters;
+	private Map<MetricName, Histogram> histograms;
+	private Map<MetricName, Meter> meters;
+	private Map<MetricName, Timer> timers;
+	private Counter counter;
+
+	@Setup(Level.Iteration)
+	public void init() throws IOException {
+		registry = new Metric2Registry();
+		for (int g = 0; g < 100; g++) {
+			Gauge<Long> gauge = new Gauge<Long>() {
+				public Long getValue() {
+					return System.currentTimeMillis();
+				}
+			};
+			registry.register(name("test_gauge_" + g).build(), gauge);
+			counter = registry.counter(name("test_counter").build());
+		}
+		gauges = registry.getGauges();
+		counters = metricNameMap(Counter.class);
+		histograms = metricNameMap(Histogram.class);
+		meters = metricNameMap(Meter.class);
+		timers = metricNameMap(Timer.class);
+
+		timestamp = System.currentTimeMillis();
+		out = new ByteArrayOutputStream();
+		HttpClient httpClient = mock(HttpClient.class);
+		when(httpClient.send(any(), any(), any(), any(), any())).thenReturn(200);
+		corePlugin = mock(CorePlugin.class);
+		final ElasticsearchClient elasticsearchClient = mock(ElasticsearchClient.class);
+		when(elasticsearchClient.isElasticsearchAvailable()).thenReturn(true);
+		when(corePlugin.getElasticsearchClient()).thenReturn(elasticsearchClient);
+		when(corePlugin.isStagemonitorActive()).thenReturn(true);
+		elasticsearchReporter = ElasticsearchReporter.forRegistry(registry, corePlugin)
+			.convertDurationsTo(DURATION_UNIT)
+			.globalTags(singletonMap("app", "benchmark"))
+			.httpClient(httpClient)
+			.build();
+
+	}
+
+	private static <T> Map<MetricName, T> metricNameMap(Class<T> clazz) {
+		return Collections.emptyMap();
+	}
+
+	@Benchmark
+	public void reportMetrics(Blackhole bh) throws IOException {
+		counter.inc();
+		elasticsearchReporter.reportMetrics(gauges, counters, histograms, meters, timers, out, bulkActionBytes, timestamp);
+	}
+}


### PR DESCRIPTION
**Problem**
Huge gc pressure in `ElasticsearchReporter::reportMetrics` often comparable to the allocation of the monitored application.

![image](https://user-images.githubusercontent.com/165260/44973010-baa52700-af20-11e8-8e1f-73010a1096af.png)

**Solution**
Close `JsonGenerator` in `ElasticsearchReporter::reportMetrics`, that allows to reuse Jackson write buffers. This simple and safe step allows to decrease the allocation of metrics reporting **by 20x (!!!)**

**Benchmarks**

Before fix:
```
Benchmark                                                                      Mode  Cnt        Score   Error   Units
ElasticsearchReporterBenchmark.reportMetrics                                   avgt        185594.758           ns/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.alloc.rate                    avgt          8332.976          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.alloc.rate.norm               avgt       1694734.589            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Eden_Space           avgt          8401.922          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Eden_Space.norm      avgt       1708756.679            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Old_Gen              avgt           138.217          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Old_Gen.norm         avgt         28110.128            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Survivor_Space       avgt             0.048          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Survivor_Space.norm  avgt             9.789            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.count                         avgt            40.000          counts
ElasticsearchReporterBenchmark.reportMetrics:·gc.time                          avgt          2138.000              ms
```

After fix:
```
Benchmark                                                                      Mode  Cnt      Score   Error   Units
ElasticsearchReporterBenchmark.reportMetrics                                   avgt       67980.404           ns/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.alloc.rate                    avgt         758.347          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.alloc.rate.norm               avgt       56820.773            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Eden_Space           avgt         432.482          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Eden_Space.norm      avgt       32404.686            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Old_Gen              avgt         311.260          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Old_Gen.norm         avgt       23321.808            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Survivor_Space       avgt           0.024          MB/sec
ElasticsearchReporterBenchmark.reportMetrics:·gc.churn.PS_Survivor_Space.norm  avgt           1.782            B/op
ElasticsearchReporterBenchmark.reportMetrics:·gc.count                         avgt           5.000          counts
ElasticsearchReporterBenchmark.reportMetrics:·gc.time                          avgt         480.000              ms
```

Allocation profile after fix ('expanded' useful 5% from original image):
![image](https://user-images.githubusercontent.com/165260/44973673-f7721d80-af22-11e8-801c-65410efbf486.png)
The described problem is completely eliminated, that makes other (minor) allocation issues visible.

**Clickable svg flamegraph profiles before and after :**
[alloc_profiles.zip](https://github.com/stagemonitor/stagemonitor/files/2344599/alloc_profiles.zip)

**Running jmh tests**
```bash
$ ./gradlew jmh
```

Flamegraphs are created with [async-profiler](https://github.com/jvm-profiling-tools/async-profiler).
for single iteration of jmh benchmark.
In order to reproduce, install async-profiler and run command like in the follofing example before jmh benchmark execution:
```bash
$ export JMH_ARGS="-Xmx8G -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -agentpath:async-profiler-1.4/build/libasyncProfiler.so=start,svg,event=alloc,file=stagemon_alloc_bench.svg"
```
