### PR TITLE
FIX: Add missing dependency

### DIFF
--- a/stagemonitor-core/build.gradle
+++ b/stagemonitor-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compile "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
 	compile "net.bytebuddy:byte-buddy:$byteBuddyVersion"
 	compile "net.bytebuddy:byte-buddy-agent:$byteBuddyVersion"
+	compile "javax.xml.bind:jaxb-api:2.3.0"
 	compile project(":stagemonitor-configuration")
 	provided "io.prometheus:simpleclient:0.0.26"
 	provided project(":stagemonitor-dispatcher")


### PR DESCRIPTION
Your project's stagemonitor-core/build.gradle has a missing dependency: javax.xml.bind package